### PR TITLE
Add review analyzer example

### DIFF
--- a/examples/review_analyzer.py
+++ b/examples/review_analyzer.py
@@ -57,6 +57,9 @@ def summarize_review(review: str) -> str:
 
 # ── Pipeline ────────────────────────────────────────────────────────────────
 # ai_functions are regular callables — compose them with plain Python.
+# These two calls are independent, so they could also be run in parallel
+# by defining the ai_functions as async and using asyncio.gather():
+#   sentiment, summary = await asyncio.gather(classify_sentiment(review), summarize_review(review))
 
 
 def analyze_review(review: str) -> dict:


### PR DESCRIPTION
Adds a new example (`review_analyzer.py`) that demonstrates features not covered by the existing examples:

- **`Literal` return type** for constrained classification — no existing example uses `Literal` as a return type
- **`PostConditionResult` from a plain Python function** — existing examples use either `assert` or `@ai_function` post-conditions, but none return `PostConditionResult` from a regular function
- **A post-condition that reliably triggers self-correction** — the ALL CAPS constraint is rarely satisfied on the first attempt, making the retry loop visible when running the example
- **Multi-step pipeline composition** — classifies sentiment then summarizes, composed with plain function calls

No new dependencies required.