### PR TITLE
ci: allow publishing pre-release versions to PyPI

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Validate version
         run: |
           version=$(hatch version)
-          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Valid version format"
+          if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$ ]]; then
+              echo "Valid version format: $version"
               exit 0
           else
-              echo "Invalid version format"
+              echo "Invalid version format: $version"
               exit 1
           fi
       - name: Build


### PR DESCRIPTION
## Summary
- Relax the version-validation regex in `pypi-publish-on-release.yml` to
accept PEP 440 pre-release suffixes (`aN`, `bN`, `rcN`), so tags such as
`v0.2.0a2` are publishable.
- Include the parsed version in the validation log line for easier diagnosis
on failure.

Pre-releases are safe to publish: `pip install strands-ai-functions` keeps
resolving to the latest stable unless the user passes `--pre` or pins an exact
 pre-release version.