### PR TITLE
Add spec/ type-stub surface for the ai_functions public API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 uv.lock
 .mypy_cache/
 .ruff_cache/
+.venv/
 
 
 # MkDocs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "pytest-cov>=4.0",
     "hypothesis>=6.0",
     "ruff>=0.1.0",
+    "mypy>=1.20.0",
     "websockets>=12.0",
     "cloudpickle>=3.0.0",
 ]
@@ -59,6 +60,7 @@ test = "pytest {args:tests}"
 test-cov = "pytest --cov=ai_functions {args:tests}"
 lint = "ruff check src tests"
 format = "ruff format src tests"
+check-spec = "MYPYPATH=spec stubtest ai_functions --mypy-config-file pyproject.toml --allowlist stubtest-allowlist.txt"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -89,6 +91,14 @@ docstring-code-format = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.mypy]
+python_version = "3.13"
+ignore_errors = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
 
 [tool.uv.workspace]
 members = ["examples"]

--- a/spec/ai_functions/__init__.pyi
+++ b/spec/ai_functions/__init__.pyi
@@ -1,0 +1,35 @@
+"""AI-enhanced functions and thread orchestration."""
+
+from .ai_thread import (
+    AIFunction,
+    AIThread,
+    DefaultSummarizationStrategy,
+    SummarizationFailedError,
+    SummarizationStrategy,
+    ai_function,
+)
+from .handle import ThreadHandle
+from .protocols import Coordinator, Spawnable, Thread
+from .runtime import (
+    InMemoryCoordinator,
+    LocalWorker,
+    WorkerAdapter,
+)
+from .utils import run_blocking
+
+__all__ = [
+    "ai_function",
+    "AIFunction",
+    "AIThread",
+    "Coordinator",
+    "DefaultSummarizationStrategy",
+    "InMemoryCoordinator",
+    "LocalWorker",
+    "run_blocking",
+    "Spawnable",
+    "SummarizationFailedError",
+    "SummarizationStrategy",
+    "Thread",
+    "ThreadHandle",
+    "WorkerAdapter",
+]

--- a/spec/ai_functions/ai_thread/__init__.pyi
+++ b/spec/ai_functions/ai_thread/__init__.pyi
@@ -1,0 +1,51 @@
+"""AIThread — live, per-spawn Strands-agent thread implementation.
+
+Exports the AIThread class, its ``AIFunction`` factory / decorator, and
+all AIThread-specific types (config, errors, post-conditions, message
+reconstruction, summarization, runtime-facing tools).
+"""
+
+from __future__ import annotations
+
+from .ai_function import AIFunction, ai_function
+from .ai_thread import AIThread, OutputSpec
+from .config import (
+    AgentKwargs,
+    CodeExecutionMode,
+    ThreadConfig,
+    ThreadKwargs,
+    ThreadMergedKwargs,
+    split_config_and_agent_kwargs,
+)
+from .errors import AIFunctionError, ValidationError
+from .postcondition import PostCondition, PostConditionResult
+from .reconstruction import reconstruct_messages, render_renderable_events
+from .summarization import (
+    DefaultSummarizationStrategy,
+    SummarizationFailedError,
+    SummarizationStrategy,
+)
+from .tools import coordinator_tools
+
+__all__ = [
+    "ai_function",
+    "AgentKwargs",
+    "AIFunction",
+    "AIFunctionError",
+    "AIThread",
+    "CodeExecutionMode",
+    "coordinator_tools",
+    "DefaultSummarizationStrategy",
+    "OutputSpec",
+    "PostCondition",
+    "PostConditionResult",
+    "reconstruct_messages",
+    "render_renderable_events",
+    "split_config_and_agent_kwargs",
+    "SummarizationFailedError",
+    "SummarizationStrategy",
+    "ThreadConfig",
+    "ThreadKwargs",
+    "ThreadMergedKwargs",
+    "ValidationError",
+]

--- a/spec/ai_functions/ai_thread/ai_function.pyi
+++ b/spec/ai_functions/ai_thread/ai_function.pyi
@@ -1,0 +1,240 @@
+"""Immutable ``@ai_function`` decorator and ``AIFunction`` template."""
+
+from __future__ import annotations
+
+from typing import Callable, Hashable, Sequence, Unpack, final, overload, override
+
+from strands.tools import ToolProvider
+from strands.types.tools import AgentTool
+
+from ..protocols import Spawnable
+from ..handle import ThreadHandle
+from .ai_thread import AIThread
+from .config import (
+    ThreadConfig,
+    ThreadMergedKwargs,
+)
+
+
+@final
+class AIFunction[**P, T](ToolProvider, Spawnable[P, T]):
+    """Immutable AI function template; factory for ``AIThread`` instances.
+
+    Args:
+        prompt_fn: User function that builds the prompt; ``None`` means
+            use the function's docstring.
+        output_type: The declared output type for this function.
+        config: Default per-thread configuration.
+
+    Implements:
+        Spawnable, strands.tools.ToolProvider.
+    """
+
+    def __init__(
+        self,
+        prompt_fn: Callable[P, str | None],
+        output_type: type[T],
+        config: ThreadConfig,
+    ) -> None: ...
+
+    @property
+    def name(self) -> str:
+        """Name of the wrapped function."""
+        ...
+
+    @property
+    def config(self) -> ThreadConfig:
+        """The default ``ThreadConfig`` attached to this template."""
+        ...
+
+    @property
+    def output_type(self) -> type[T]:
+        """The declared output type for this function."""
+        ...
+
+    @property
+    def prompt_fn(self) -> Callable[P, str | None]:
+        """The user-provided prompt builder."""
+        ...
+
+    # ── Spawnable ──
+
+    def to_thread(
+        self,
+        **config_overrides: Unpack[ThreadMergedKwargs],
+    ) -> AIThread[P, T]:
+        """Produce a fresh ``AIThread`` bound to this template.
+
+        Args:
+            config_overrides: Kwargs matching ``ThreadConfig`` fields update
+                the config directly; others merge into ``agent_kwargs``.
+
+        Returns:
+            A new ``AIThread`` with its own buffer and resolved config.
+
+        Ensures:
+            - The returned thread is unbound.
+            - Successive calls return independent instances with no
+              shared state.
+        """
+        ...
+
+    # ── One-shot execution (sugar) ──
+
+    async def spawn(
+        self,
+        **config_overrides: Unpack[ThreadMergedKwargs],
+    ) -> ThreadHandle[P, T]:
+        """Spawn this template on a private in-process worker and return its handle.
+
+        Convenience for scripts and examples that want a multi-turn
+        session without standing up a coordinator and worker pair
+        explicitly. The returned handle is backed by a coordinator owned
+        by a fresh :class:`LocalWorker`; both stay alive for as long as
+        the handle is reachable.
+
+        Args:
+            config_overrides: Kwargs matching ``ThreadConfig`` fields update
+                the config directly; others merge into ``agent_kwargs``.
+
+        Returns:
+            A ``ThreadHandle`` in ``NOT_STARTED`` state bound to a
+            private worker.
+
+        Ensures:
+            - Each call returns a handle on an independent worker with
+              no shared state.
+            - The caller owns the handle's lifecycle; teardown requires
+              ``await handle.terminate()`` or
+              ``await handle.terminate_now()``.
+
+        Strategy:
+            1. Merge ``config_overrides`` into this template
+               (``self.replace``) if any.
+            2. Construct a fresh :class:`InMemoryCoordinator` and
+               :class:`LocalWorker`.
+            3. ``await worker.spawn_locally(target)`` and return the handle.
+        """
+        ...
+
+    async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
+        """Run one throwaway cycle standalone and return the result.
+
+        Args:
+            args: Positional arguments forwarded to ``prompt_fn``.
+            kwargs: Keyword arguments forwarded to ``prompt_fn``.
+
+        Returns:
+            The typed cycle result.
+
+        Strategy:
+            1. ``handle = self.spawn()``.
+            2. ``await handle.run(*args, **kwargs)``.
+            3. ``await handle.terminate_now()``.
+        """
+        ...
+
+    def run_sync(self, *args: P.args, **kwargs: P.kwargs) -> T:
+        """Blocking wrapper around ``__call__``.
+
+        Args:
+            args: Positional arguments forwarded to ``prompt_fn``.
+            kwargs: Keyword arguments forwarded to ``prompt_fn``.
+
+        Returns:
+            The typed cycle result.
+
+        Concurrency:
+            Blocks the calling thread until the cycle completes.
+        """
+        ...
+
+    # ── Template variants ──
+
+    def replace(self, **kwargs: Unpack[ThreadMergedKwargs]) -> AIFunction[P, T]:
+        """Return a new template with ``kwargs`` merged into its config.
+
+        Args:
+            kwargs: Kwargs matching ``ThreadConfig`` fields update the
+                config directly; others merge into ``agent_kwargs``.
+
+        Returns:
+            A new ``AIFunction`` that differs from ``self`` only in the
+            merged fields.
+        """
+        ...
+
+    # ── ToolProvider ──
+
+    @override
+    async def load_tools(self, **kwargs: object) -> Sequence[AgentTool]:
+        """Expose this template as a Strands tool for other agents.
+
+        Args:
+            kwargs: Ignored; present for protocol compatibility.
+
+        Returns:
+            One or more ``AgentTool`` instances whose invocation calls
+            ``__call__``.
+        """
+        ...
+
+    @override
+    def add_consumer(self, consumer_id: Hashable, **kwargs: object) -> None:
+        """Register a tool-provider consumer.
+
+        Args:
+            consumer_id: Identifier of the agent consuming this tool.
+            kwargs: Ignored; present for protocol compatibility.
+        """
+        ...
+
+    @override
+    def remove_consumer(self, consumer_id: Hashable, **kwargs: object) -> None:
+        """Deregister a tool-provider consumer.
+
+        Args:
+            consumer_id: Identifier of the agent releasing this tool.
+            kwargs: Ignored; present for protocol compatibility.
+        """
+        ...
+
+
+# ── Decorator ──
+
+
+@overload
+def ai_function[**P, T](
+    output: type[T],
+) -> Callable[[Callable[P, str | None]], AIFunction[P, T]]: ...
+
+
+@overload
+def ai_function[**P, T](
+    output: type[T],
+    *,
+    config: ThreadConfig | None = None,
+    **kwargs: Unpack[ThreadMergedKwargs],
+) -> Callable[[Callable[P, str | None]], AIFunction[P, T]]: ...
+
+
+def ai_function[**P, T](  # type: ignore[misc]
+    output: type[T],
+    *,
+    config: ThreadConfig | None = None,
+    **kwargs: Unpack[ThreadMergedKwargs],
+) -> Callable[[Callable[P, str | None]], AIFunction[P, T]]:
+    """Wrap a prompt function as an ``AIFunction`` with the given output type.
+
+    Args:
+        output: The declared output type for the wrapped function.
+        config: Optional base ``ThreadConfig``; a fresh one is used if
+            ``None``.
+        kwargs: Overrides merged into ``config``; ``ThreadKwargs`` keys
+            update config fields directly, others merge into
+            ``agent_kwargs``.
+
+    Returns:
+        A decorator that turns the prompt function into an ``AIFunction``.
+    """
+    ...

--- a/spec/ai_functions/ai_thread/ai_thread.pyi
+++ b/spec/ai_functions/ai_thread/ai_thread.pyi
@@ -1,0 +1,324 @@
+"""AIThread — live, per-spawn instance backing an ``AIFunction``."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, final
+
+from pydantic import BaseModel
+from strands import Agent
+from strands.agent.agent_result import AgentResult
+from strands.hooks import HookProvider
+from strands.types.content import Messages
+
+from ..protocols import Thread
+from ..types import ThreadContext
+from .config import ThreadConfig
+from .postcondition import PostCondition
+
+if TYPE_CHECKING:
+    from .ai_function import AIFunction
+
+
+@dataclass(frozen=True)
+class OutputSpec[T]:
+    """Describes the AI output type and how to present it to the model."""
+
+    output_type: type[T]
+    """The user-specified output type (e.g. ``str``, ``float``, a pydantic
+    model)."""
+
+    is_pydantic: bool
+    """True iff ``output_type`` is a ``pydantic.BaseModel`` subclass."""
+
+    is_structured: bool
+    """True iff the output can be expressed as a JSON schema for the model."""
+
+    structured_output_model: type[BaseModel] | None
+    """Pydantic model passed to Strands as the structured output model."""
+
+    is_wrapped: bool
+    """True iff ``structured_output_model`` wraps ``output_type`` in a
+    ``FinalAnswer``."""
+
+    @classmethod
+    def from_type(cls, output_type: type[T], is_structured: bool = True) -> OutputSpec[T]:
+        """Derive an ``OutputSpec`` from a type and a structured-output flag.
+
+        Args:
+            output_type: The user-declared output type.
+            is_structured: Whether structured output should be used if
+                possible.
+
+        Returns:
+            An ``OutputSpec`` describing how to request and parse
+            ``output_type``.
+
+        Ensures:
+            - ``result.is_pydantic`` is true iff ``output_type`` is a
+              ``BaseModel`` subclass.
+            - ``result.structured_output_model is not None`` iff
+              ``result.is_structured``.
+            - ``result.is_wrapped`` is true iff
+              ``structured_output_model`` wraps ``output_type``.
+        """
+        ...
+
+
+@final
+class AIThread[**P, T](Thread[P, T]):
+    """Live stateful thread instance bound to an ``AIFunction`` template.
+
+    Args:
+        template: The ``AIFunction`` whose ``prompt_fn`` and
+            ``output_type`` this thread invokes.
+        config: The resolved ``ThreadConfig`` (template config merged
+            with overrides).
+
+    Raises:
+        AIFunctionError: The resolved config sets
+            ``agent_kwargs["conversation_manager"]`` to a non-``None``
+            value (the runtime owns conversation history; a user-supplied
+            manager would desynchronize ``agent.messages`` from the
+            event log and break I7/I9).
+
+    Implements:
+        Thread.
+    """
+
+    def __init__(
+            self,
+            template: "AIFunction[P, T]",
+            config: ThreadConfig,
+    ) -> None: ...
+
+    # ── Thread ──
+
+    @property
+    def name(self) -> str:
+        """Thread name, taken from the owning ``AIFunction``."""
+        ...
+
+    async def notify(self, text: str) -> None:
+        """Buffer ``text`` for observation at the next model-call boundary.
+
+        Args:
+            text: Message body delivered by the runtime or an external sender.
+
+        Ensures:
+            - ``text`` is appended to the thread-local inject buffer.
+            - The next :meth:`execute` cycle observes ``text`` on its first
+              model-call boundary via the event-bridge hook.
+        """
+        ...
+
+    async def execute(self, ctx: ThreadContext, *args: P.args, **kwargs: P.kwargs) -> T:
+        """Render a prompt and drive the executor for one cycle.
+
+        Builds the prompt via ``self._generate_prompt`` and appends it to
+        the thread's inject buffer (after any messages already pending from
+        :meth:`notify`); the event-bridge hook atomically emits one
+        ``MESSAGE_USER`` event per buffer entry and injects the matching
+        user turn into the live Strands agent at the first
+        ``BeforeModelCallEvent`` boundary (I7).
+
+        Args:
+            ctx: Freshly built per-cycle context.
+            args: Positional arguments forwarded to ``template.prompt_fn``.
+            kwargs: Keyword arguments forwarded to ``template.prompt_fn``.
+
+        Returns:
+            The typed cycle result.
+
+        Requires:
+            ``ctx`` is a fresh context built by the runtime for this cycle.
+
+        Emits:
+            MESSAGE_USER — one per drained buffer entry, via the
+            event-bridge hook.
+
+        Strategy:
+            1. Call ``self._generate_prompt`` to produce the prompt string.
+            2. Append the prompt to ``self._inject_buffer`` so the
+               event-bridge hook emits it (and injects it into the live
+               agent) atomically at the first ``BeforeModelCallEvent``,
+               after any pending inject messages.
+            3. Call ``self._run_cycle(ctx)`` and return its result.
+        """
+        ...
+
+    # ── Internal pipeline steps ──
+
+    async def _run_cycle(self, ctx: ThreadContext) -> T:
+        """Run the shared agent execution loop for one cycle.
+
+        Args:
+            ctx: Freshly built per-cycle context.
+
+        Returns:
+            The typed result produced by the agent.
+
+        Strategy:
+            1. Call ``self._config.config_hook(ctx)`` if set and merge the
+               returned ``ThreadKwargs`` into a cycle-local config
+               (``config_hook`` key itself ignored).
+            2. Call ``reconstruct_messages(await
+               ctx.coordinator.get_events(ctx.thread_id))`` to obtain the
+               up-to-date message history.
+            3. Call ``self._build_agent`` to create a Strands ``Agent``.
+            4. ``await agent.invoke_async(messages=messages)``.
+            5. On interrupts, ``await ctx.on_interrupt(batch)`` and
+               resume with decisions.
+            6. Call ``self._extract_result`` to extract the typed result.
+            7. Emit ``TOKEN_USAGE`` via ``ctx.on_event``.
+            8. Run post-conditions via ``self._validate_result``; on
+               failure, put the error text on ``ctx.message_queue`` (the
+               hook emits ``MESSAGE_USER`` on the next drain — I7) and
+               retry from step 2 up to ``cycle_config.max_attempts``
+               times.
+            9. Return the typed and validated result.
+        """
+        ...
+
+    def _build_agent(
+            self,
+            messages: Messages,
+            cycle_config: ThreadConfig,
+            extra_hooks: list[HookProvider] | None,
+            callback_handler: Callable[..., None] | None = None,
+    ) -> Agent:
+        """Assemble a configured Strands ``Agent`` for one cycle.
+
+        Args:
+            messages: Current conversation history passed to the agent.
+            cycle_config: The merged per-cycle config.
+            extra_hooks: Extra Strands hooks wired into the agent.
+            callback_handler: Strands ``callback_handler`` for per-chunk
+                streaming callbacks.
+
+        Returns:
+            A freshly constructed Strands ``Agent``.
+
+        Strategy:
+            1. If ``cycle_config.structured_output`` is ``False``, check
+               that ``output_type`` is ``str`` or raise.
+            2. If ``structured_output`` is ``True`` and ``output_type`` is
+               not a pydantic model, create a pydantic wrapper
+               ``class FinalAnswer: answer: output_type``.
+            3. Build a Strands agent with the extra hooks wired in (these
+               include the event-bridge hook that drains
+               ``message_queue``, checks ``cancel_signal``, awaits
+               ``pause_signal``, and emits assistant/tool telemetry
+               events); if ``structured_output`` is ``True``, set
+               ``structured_output_model`` to ``output_type`` or the
+               wrapper; pass any field from ``cycle_config`` that applies
+               to ``strands.Agent.__init__``.
+        """
+        ...
+
+    def _generate_prompt(self, *args: P.args, **kwargs: P.kwargs) -> str:
+        """Render the prompt string from template arguments.
+
+        Args:
+            args: Positional arguments forwarded from ``execute``.
+            kwargs: Keyword arguments forwarded from ``execute``.
+
+        Returns:
+            The rendered prompt string.
+
+        Raises:
+            AIFunctionError: ``prompt_fn`` returned ``None`` and the
+                function has no docstring.
+
+        Strategy:
+            1. Call ``self._template.prompt_fn(*args, **kwargs)``.
+            2. If ``prompt_fn`` returns ``None``, interpret
+               ``prompt_fn.__doc__`` as a ``tstr`` template and
+               interpolate it using the function arguments and their
+               enclosing globals as context.
+            3. If there is no docstring either, raise ``AIFunctionError``.
+        """
+        ...
+
+    def _extract_result(self, response: AgentResult, state: dict[str, object]) -> T:
+        """Extract the typed result from a Strands ``AgentResult``.
+
+        Args:
+            response: The Strands agent result.
+            state: Per-cycle execution state.
+
+        Returns:
+            The typed result as declared by ``output_type``.
+        """
+        ...
+
+    async def _validate_result(
+            self,
+            result: T,
+            bound_args: dict[str, object],
+            post_conditions: tuple[PostCondition, ...],
+            function_name: str,
+    ) -> list[str]:
+        """Evaluate every post-condition against ``result`` in parallel.
+
+        If a condition raises an exception, it is considered failed and
+        the exception text is used as the error message.
+
+        Args:
+            result: The candidate typed result.
+            bound_args: Bound arguments for condition callables that
+                accept them.
+            post_conditions: Ordered tuple of validators from
+                ``ThreadConfig``.
+            function_name: Name of the owning function (for error
+                attribution).
+
+        Returns:
+            A list of error messages from failed post-conditions.
+        """
+        ...
+
+    async def fork(self) -> "AIFunction[P, T]":
+        """Return the owning template as a resumption ``Spawnable``.
+
+        ``AIThread`` carries no per-instance state beyond the event log
+        (which the runtime seeds separately via
+        :meth:`Coordinator.copy_events`), so the original template is
+        itself a valid resumption spawnable.
+
+        Note:
+            The fork intentionally does NOT inherit the current thread's
+            inject buffer. Pending ``notify`` entries that have
+            not yet been observed by a cycle are dropped from the forked
+            thread's perspective — the fork starts with an empty buffer.
+
+        Returns:
+            ``self.template`` — the ``AIFunction`` this thread was
+            spawned from.
+        """
+        ...
+
+    async def teardown(self) -> None:
+        """Release per-instance state on termination.
+
+        Drops the inject buffer. ``AIThread`` owns no other external
+        resources.
+        """
+        ...
+
+    # ── Introspection ──
+
+    @property
+    def template(self) -> "AIFunction[P, T]":
+        """The template this thread was created from."""
+        ...
+
+    @property
+    def config(self) -> ThreadConfig:
+        """Resolved config.
+
+        ``template.config`` merged with ``to_thread`` overrides.
+        """
+        ...
+

--- a/spec/ai_functions/ai_thread/config.pyi
+++ b/spec/ai_functions/ai_thread/config.pyi
@@ -1,0 +1,173 @@
+"""Per-thread execution configuration and its matching kwargs ``TypedDict`` s.
+
+Invariants:
+    ``ThreadConfig`` fields exactly match ``ThreadKwargs`` annotations.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Mapping, TypedDict, Unpack
+
+from strands.types.tools import AgentTool
+JSONSchema = dict[str, Any]  # pyright: ignore[reportExplicitAny]
+
+from .postcondition import PostCondition
+
+if TYPE_CHECKING:
+    from ..types import ThreadContext
+    from .summarization import SummarizationStrategy
+    from strands.agent import ConversationManager
+    from strands.agent.state import AgentState
+    from strands.hooks import HookProvider
+    from strands.models import Model
+    from strands.session import SessionManager
+    from strands.tools import ToolProvider
+    from strands.tools.executors._executor import ToolExecutor
+    from strands.types.content import Messages
+    from strands.types.traces import AttributeValue
+
+
+class CodeExecutionMode(enum.StrEnum):
+    """Code-execution mode for Python tool calls."""
+
+    LOCAL = "local"
+    """Execute code in the current process (default)."""
+
+    DISABLED = "disabled"
+    """No code execution — rely solely on structured output."""
+
+
+class AgentKwargs(TypedDict, total=False):
+    """Kwargs pass-through for the ``strands.Agent`` constructor.
+
+    ``conversation_manager`` is accepted in this mapping but must always
+    be left unset (or explicitly ``None``) by users. The runtime manages
+    conversation history through the event log and installs
+    ``NullConversationManager`` on every ``Agent`` it builds; a
+    user-supplied manager would mutate ``agent.messages`` behind the
+    runtime's back and desynchronize it from the event log, breaking I7
+    and I9.
+    Setting this key to any non-``None`` value is rejected at config
+    resolution with ``AIFunctionError``.
+    """
+
+    messages: "Messages | None"
+    callback_handler: Callable[..., Any] | None  # pyright: ignore[reportExplicitAny]
+    conversation_manager: "ConversationManager | None"
+    record_direct_tool_call: bool
+    load_tools_from_directory: bool
+    trace_attributes: "Mapping[str, AttributeValue] | None"
+    agent_id: str | None
+    state: "AgentState | dict[str, Any] | None"  # pyright: ignore[reportExplicitAny]
+    hooks: "list[HookProvider] | None"
+    session_manager: "SessionManager | None"
+    tool_executor: "ToolExecutor | None"
+
+
+class ThreadKwargs(TypedDict, total=False):
+    """Kwargs mirror of ``ThreadConfig`` fields; enforced equal at module load."""
+
+    model: "Model | str | None"
+    system_prompt: str | None
+    tools: "list[AgentTool | ToolProvider | str] | None"
+    post_conditions: list[PostCondition]
+    max_attempts: int
+    structured_output: bool
+    agent_kwargs: AgentKwargs
+    name: str | None
+    description: str | None
+    input_schema: JSONSchema | None
+    thread_name: str | None
+    config_hook: "Callable[[ThreadContext], ThreadKwargs] | None"
+    summarization_strategy: "SummarizationStrategy | None"
+
+
+class ThreadMergedKwargs(AgentKwargs, ThreadKwargs):
+    """Union of ``AgentKwargs`` and ``ThreadKwargs`` for decorator kwargs typing."""
+
+
+@dataclass(frozen=True)
+class ThreadConfig:
+    """Immutable configuration for one thread's execution.
+
+    Invariants:
+        Field names equal ``ThreadKwargs`` annotation keys (enforced at
+        module load).
+    """
+
+    model: "Model | str | None" = None
+    """LLM model to use for the agent."""
+    system_prompt: str | None = None
+    """System prompt for the agent."""
+    tools: "tuple[AgentTool | ToolProvider | str, ...]" = ()
+    """Tools provided to the agent."""
+    post_conditions: tuple[PostCondition, ...] = ()
+    """List of functions to call to validate the output."""
+    max_attempts: int = 10
+    """Maximum number of times to retry producing an output that satisfies
+    the post-conditions."""
+    structured_output: bool = True
+    """Whether to use structured output mode (agent has to call a tool to
+    provide an answer). Can be ``False`` only if the output type is ``str``."""
+
+    agent_kwargs: AgentKwargs = field(default_factory=AgentKwargs)
+    """Extra kwargs forwarded to ``strands.Agent``."""
+
+    name: str | None = None
+    """Name used when the thread is made available as a tool."""
+    description: str | None = None
+    """Description used when the thread is made available as a tool."""
+    input_schema: JSONSchema | None = None
+    """Override the ``input_schema`` when the thread is made available as a tool."""
+
+    thread_name: str | None = None
+    """Name of the thread for visualization purposes."""
+
+    config_hook: "Callable[[ThreadContext], ThreadKwargs] | None" = None
+    """Optional per-cycle config patch.
+
+    Called at the start of every cycle with the current ``ThreadContext``.
+    The returned ``ThreadKwargs`` is merged into this config for that
+    cycle only — ``self`` is never mutated. Useful for injecting
+    cycle-specific tools or overriding model/system_prompt per-cycle.
+
+    Merge semantics: all fields replace the base config value if present
+    in the returned dict (including ``tools``). ``config_hook`` itself is
+    excluded from the merge. ``config_hook`` is NOT re-invoked during
+    summarization; the already-resolved cycle config is passed to the
+    strategy verbatim so a fork-based strategy can keep the cached prompt
+    prefix valid.
+
+    Concurrency:
+        Called synchronously inside ``_run_cycle``; must not block.
+    """
+
+    summarization_strategy: "SummarizationStrategy | None" = None
+    """Strategy that decides how to compact the history on context overflow.
+
+    ``None`` (default) uses ``DefaultSummarizationStrategy`` with its own
+    defaults. Set to a custom implementation to override the full
+    summarization policy. See :class:`SummarizationStrategy` for the
+    contract.
+    """
+
+
+def split_config_and_agent_kwargs(
+    **kwargs: Unpack[ThreadMergedKwargs],
+) -> tuple[ThreadKwargs, AgentKwargs]:
+    """Partition merged kwargs into ``ThreadConfig`` fields and ``Agent`` kwargs.
+
+    Args:
+        kwargs: Keys drawn from ``ThreadMergedKwargs``.
+
+    Returns:
+        ``(thread_kwargs, agent_kwargs)`` disjoint on keys, union equal
+        to ``kwargs``.
+
+    Ensures:
+        - ``thread_kwargs`` keys are a subset of ``ThreadConfig`` field names.
+        - ``agent_kwargs`` keys are disjoint from ``ThreadConfig`` field names.
+    """
+    ...

--- a/spec/ai_functions/ai_thread/errors.pyi
+++ b/spec/ai_functions/ai_thread/errors.pyi
@@ -1,0 +1,32 @@
+"""Error types raised by AI function execution."""
+
+from __future__ import annotations
+
+
+class AIFunctionError(Exception):
+    """Base error for AI function execution failures.
+
+    Args:
+        message: Human-readable explanation.
+        function_name: Name of the ``AIFunction`` that raised.
+    """
+
+    function_name: str
+
+    def __init__(self, message: str, function_name: str = "") -> None: ...
+
+
+class ValidationError(AIFunctionError):
+    """Post-condition validation failed for a cycle's result.
+
+    Args:
+        function_name: Name of the ``AIFunction`` whose result failed.
+        errors: Post-condition name → failure message.
+
+    Ensures:
+        The formatted message joins ``errors`` as ``"k: v; ..."``.
+    """
+
+    validation_errors: dict[str, str]
+
+    def __init__(self, function_name: str, errors: dict[str, str]) -> None: ...

--- a/spec/ai_functions/ai_thread/postcondition.pyi
+++ b/spec/ai_functions/ai_thread/postcondition.pyi
@@ -1,0 +1,46 @@
+"""Post-condition validator types."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from pydantic import BaseModel, Field
+
+
+class PostConditionResult(BaseModel):
+    """Outcome of running a single post-condition validator.
+
+    Invariants:
+        ``passed is False`` implies ``message is not None``.
+    """
+
+    passed: bool = Field(description="Whether the condition passed")
+    message: str | None = Field(default=None, description="Validation message")
+
+    def model_post_init(self, __context: object) -> None:
+        """Validate the ``passed``/``message`` invariant after construction.
+
+        Args:
+            __context: Pydantic-internal post-init context (unused).
+
+        Raises:
+            ValueError: ``passed`` is false and ``message`` is ``None``.
+        """
+        ...
+
+
+PostCondition = Callable[..., "PostConditionResult | None"]
+"""Callable validating an AI function result.
+
+The callable receives the result as the first positional argument. If any
+argument names in the signature of the callable match keys in
+``bound_args``, the callable also receives those values as keyword
+arguments.
+
+Return values:
+
+- ``PostConditionResult(passed=True)`` / ``None`` — condition passed.
+- ``PostConditionResult(passed=False, message=...)`` — condition failed.
+- Raising an exception — treated as a failed condition whose message is
+  the exception text.
+"""

--- a/spec/ai_functions/ai_thread/reconstruction.pyi
+++ b/spec/ai_functions/ai_thread/reconstruction.pyi
@@ -1,0 +1,77 @@
+"""Rebuild Strands-format message history from a stored event sequence."""
+
+from __future__ import annotations
+
+from strands.types.content import Messages
+
+from ..types import Event, RenderableEvent
+
+
+def render_renderable_events(events: list[RenderableEvent]) -> Messages:
+    """Render a sequence of :data:`RenderableEvent` s into Strands ``Messages``.
+
+    The pure-rendering core. Assumes the caller has already handled any
+    ``ContextSummarizedEvent`` boundaries and filtered out
+    observability-only events that carry no conversational content; this
+    function walks what remains and emits the matching message list. It
+    does not run the I10 healing pass — that is
+    :func:`reconstruct_messages`'s responsibility, so the healer runs
+    exactly once on the fully-assembled message list.
+
+    Args:
+        events: Renderable events in chronological order.
+
+    Returns:
+        The Strands ``Messages`` list these events produce.
+
+    Ensures:
+        - Each :class:`MessageUserEvent` yields one user ``Message`` with
+          a single text block (see I7).
+        - Each :class:`MessageAssistantCompleteEvent` yields one assistant
+          ``Message`` whose content is the stored list of content blocks.
+        - A contiguous run of :class:`ToolResultEvent` events collapses
+          into one user ``Message`` carrying one ``toolResult`` block per
+          event; a subsequent ``MessageUserEvent``,
+          ``MessageAssistantCompleteEvent``, or end-of-list flushes the
+          group.
+        - :class:`ToolCallEvent` is observability-only and produces no
+          message.
+    """
+    ...
+
+
+def reconstruct_messages(events: list[Event]) -> Messages:
+    """Convert stored events into a Strands-format ``Messages`` list.
+
+    Args:
+        events: Events for one thread in chronological order.
+
+    Returns:
+        A message list ready for a Strands agent.
+
+    Requires:
+        ``events`` is sorted by append order (oldest first).
+
+    Ensures:
+        - If the input contains one or more
+          :class:`ContextSummarizedEvent` events, the one with the
+          greatest index (the last one in append order) defines a
+          boundary: every event at that index or earlier is dropped from
+          rendering and ``event.new_history`` is rendered in its place
+          via :func:`render_renderable_events`, then events strictly
+          after the boundary render normally and append to the result.
+        - Events outside the renderable subset — lifecycle, token-usage,
+          session, approval, streaming fragments — are filtered out
+          before rendering.
+        - The output obeys every ``Ensures`` of
+          :func:`render_renderable_events`.
+        - Every ``toolUse`` block in the reconstructed history is
+          followed by a matching ``toolResult`` block (I10). Where the
+          event log contains no matching ``TOOL_RESULT``, the missing
+          blocks are synthesized by Strands'
+          ``generate_missing_tool_result_content`` helper — the same text
+          and shape Strands' own session manager produces when it detects
+          orphaned ``toolUse``. The I10 healing pass runs exactly once,
+          on the fully-assembled message list, after any summary splice.
+    """
+    ...

--- a/spec/ai_functions/ai_thread/summarization.pyi
+++ b/spec/ai_functions/ai_thread/summarization.pyi
@@ -1,0 +1,152 @@
+"""Pluggable conversation-summarization strategies."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ..types import Event, RenderableEvent, ThreadContext
+from .config import ThreadConfig
+from .errors import AIFunctionError
+
+
+@runtime_checkable
+class SummarizationStrategy(Protocol):
+    """Produce a compacted history for a thread whose context is too long.
+
+    Strategies are the pluggable decision layer for context management: they choose
+    which model to call, what to preserve verbatim, and what to fold into a synthetic
+    summary. Built-in implementations live in :mod:`ai_functions.summarization`; user code
+    may supply its own. A thread selects its strategy via
+    :attr:`ThreadConfig.summarization_strategy`.
+    """
+
+    async def summarize(
+        self,
+        events: list[Event],
+        ctx: ThreadContext,
+        cycle_config: ThreadConfig,
+    ) -> list[RenderableEvent]:
+        """Compact ``events`` into a shorter synthetic history.
+
+        Invoked by the thread when its accumulated event log exceeds the configured
+        context bounds. The returned list is appended as the ``new_history`` payload
+        of a :class:`ContextSummarizedEvent`; on the next reconstruction every event
+        before that marker is dropped and the returned list is rendered in its place.
+
+        Args:
+            events: Full event log at the moment summarization was triggered.
+            ctx: Per-cycle context of the thread requesting summarization.
+            cycle_config: Resolved cycle config the parent thread was using when the
+                overflow occurred.
+
+        Returns:
+            A synthetic sequence of renderable events representing the
+            compacted history.
+
+        Requires:
+            ``events`` is sorted by append order (oldest first).
+
+        Ensures: - The first event in the returned list (when present) has user-turn
+        semantics on render. - Every ``toolUse`` block reachable through the returned
+        events has a matching ``toolResult`` event later in the list, or will be
+        healed by :func:`reconstruct_messages` (I10).
+
+        Raises:
+            SummarizationFailedError: No useful compaction could be produced.
+
+        Concurrency:
+            May perform I/O (model calls, runtime spawns). Must not emit events
+            on the parent thread directly: the runtime is the sole emitter of the outer
+            `ContextSummarizedEvent` tied to this summarization.
+        """
+        ...
+
+
+class DefaultSummarizationStrategy:
+    """Summarize a prefix via a model call, preserve a bounded tail.
+
+    The built-in strategy. It chooses a tail of recent messages to keep verbatim (
+    bounded below by ``preserve_min_messages`` / ``preserve_min_tokens`` and above by
+    ``preserve_max_tokens``), advances the split to a legal tool-pair boundary (I10),
+    and replaces everything before the split with a single synthetic user turn
+    carrying a narrative summary produced by a helper thread.
+
+    The helper-thread path is governed by ``summarize_by_forking``:
+
+    - ``True`` — the helper inherits the parent's resolved cycle config (same model,
+      system prompt, tools; tool execution denied via an internal hook).
+      Requires ``cycle_config.structured_output is False``.
+    - ``False`` — the helper uses a minimal dedicated config: parent's
+      model only, no tools, a hard-coded summarization system prompt.
+    - ``None`` — resolves to ``True`` iff ``cycle_config.structured_output is False``,
+      else ``False``. Resolved per call, so one instance is reusable across threads with
+      different output shapes.
+
+    Args:
+        summarize_by_forking: Fork policy (see above). ``None`` resolves lazily per call
+            based on ``cycle_config``.
+        preserve_min_messages: Floor on the number of tail messages kept verbatim.
+        preserve_min_tokens: Floor on the number of tokens (estimated) kept verbatim.
+        preserve_max_tokens: Ceiling on the number of tokens (estimated) kept verbatim.
+            Messages that push the tail past this bound are summarized instead.
+
+    Requires:
+        - ``preserve_min_messages >= 1``.
+        - ``preserve_min_tokens <= preserve_max_tokens``.
+
+    Raises:
+        ValueError: A ``Requires`` clause is violated.
+    """
+
+    def __init__(
+        self,
+        *,
+        summarize_by_forking: bool | None = None,
+        preserve_min_messages: int = 6,
+        preserve_min_tokens: int = 4_000,
+        preserve_max_tokens: int = 40_000,
+    ) -> None: ...
+
+    async def summarize(
+        self,
+        events: list[Event],
+        ctx: ThreadContext,
+        cycle_config: ThreadConfig,
+    ) -> list[RenderableEvent]:
+        """Produce the compacted history per the class docstring algorithm.
+
+        See :meth:`SummarizationStrategy.summarize` for the full protocol contract (
+        ordering requirement on ``events``, rendering guarantees on the returned
+        list, concurrency rules). This implementation additionally guarantees the
+        shape below.
+
+        Args:
+            events: Parent thread's full event log at summarization time.
+            ctx: Parent thread's per-cycle context.
+            cycle_config: Parent thread's resolved cycle config.
+
+        Returns:
+            ``[MessageUserEvent(summary_text), *preserved_events]``.
+
+        Raises:
+            SummarizationFailedError: The history cannot be compacted at the  configured
+                bounds, the helper thread failed, or ``summarize_by_forking=True`` was
+                requested against a structured-output parent with a non-``str`` output.
+        """
+        ...
+
+
+class SummarizationFailedError(AIFunctionError):
+    """Summarization could not produce a usable compaction.
+
+    Raised when every available strategy attempt fails to fit within the model's
+    context window, or when no legal split point exists (for instance, a single
+    preserved message is itself larger than the context limit). Unrecoverable by
+    retry; callers must intervene (reset session, change config, shrink tool outputs).
+
+    Args:
+        function_name: Name of the ``AIFunction`` whose thread attempted summarization.
+        reason: Short explanation of why summarization could not succeed.
+    """
+
+    def __init__(self, function_name: str, reason: str) -> None: ...

--- a/spec/ai_functions/ai_thread/tools.pyi
+++ b/spec/ai_functions/ai_thread/tools.pyi
@@ -1,0 +1,56 @@
+"""Coordinator-facing tools exposed to LLM agents.
+
+Each tool is a Strands ``@tool``-decorated coroutine that closes over a
+:class:`ThreadContext` so the calling agent can reach the coordinator.
+The default ``config_hook`` installed on every ``AIFunction`` calls
+:func:`coordinator_tools` with the cycle's ``ctx`` and appends the
+result to ``cycle_config.tools``.
+
+Two tools are exposed:
+
+- ``list_threads()`` — return a JSON-friendly snapshot of every thread
+  registered with the calling agent's coordinator, including a
+  ``is_self`` flag marking the calling thread.
+- ``send_message(thread_id, message, mode="wait")`` — invoke a peer
+  thread via its typed ``run(message)`` entry point. The peer must have
+  ``input_shape == STR_PROMPT``. ``mode`` selects how the sender relates
+  to the peer's result:
+
+  - ``"wait"`` (default): await the peer's cycle; return its reply as
+    the tool's result. Blocks the sender's cycle on the peer's cycle.
+  - ``"fire_and_forget"``: schedule the peer's cycle as a background
+    task; return immediately. The peer's reply is discarded.
+  - ``"continue_then_receive"``: schedule the peer's cycle, return
+    immediately, and when the peer completes, enqueue a fresh cycle on
+    the sender with the peer's reply formatted as the user turn. This
+    mode requires the sender itself to have ``input_shape == STR_PROMPT``
+    — the tool returns an error otherwise, asking the agent to use
+    ``"wait"``.
+
+These tools are LLM-facing. Application code that wants the old
+inject-then-no-cycle semantics should call
+``ctx.coordinator.notify(...)`` directly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from strands.types.tools import AgentTool
+
+from ..types import ThreadContext
+
+
+def coordinator_tools(ctx: ThreadContext) -> Sequence[AgentTool]:
+    """Build the list of coordinator-facing tools bound to ``ctx``.
+
+    Args:
+        ctx: The current cycle's context. Captured by the returned
+            tools so they can reach ``ctx.coordinator`` when invoked.
+
+    Returns:
+        A fresh list of ``AgentTool`` instances — one per tool. Each
+        invocation uses ``ctx.coordinator`` and ``ctx.thread_id``
+        captured at build time.
+    """
+    ...

--- a/spec/ai_functions/handle.pyi
+++ b/spec/ai_functions/handle.pyi
@@ -1,0 +1,189 @@
+"""Thread reference returned by ``coordinator.spawn`` / ``worker.spawn_locally``."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, final
+
+from .types import ThreadId, ThreadStatus
+
+if TYPE_CHECKING:
+    from .protocols import Coordinator
+
+
+@final
+class ThreadHandle[**P, T]:
+    """Thin ``(thread_id, coordinator)`` reference delegating every operation.
+
+    Every method forwards to the coordinator, which routes to the
+    hosting worker via its registered adapter. The handle itself holds
+    no per-thread state; one handle type works across any coordinator
+    implementation (in-memory, remote, test double).
+
+    Args:
+        thread_id: Runtime-assigned id of an already-registered thread.
+        coordinator: Coordinator responsible for routing operations on
+            this thread.
+
+    Lifecycle:
+        NOT_STARTED -> RUNNING -> {IDLE, PAUSED, CANCELLED} ->
+        {TERMINATED, FAILED}.
+    """
+
+    def __init__(self, thread_id: ThreadId, coordinator: Coordinator) -> None: ...
+
+    @property
+    def id(self) -> ThreadId:
+        """Thread id this handle refers to."""
+        ...
+
+    async def status(self) -> ThreadStatus:
+        """Return the runtime-maintained status of the thread.
+
+        Returns:
+            The status the coordinator currently attributes to the thread.
+
+        Raises:
+            ThreadNotFoundError: The thread is no longer registered.
+
+        Concurrency:
+            Awaits the coordinator; remote coordinators round-trip to the server.
+        """
+        ...
+
+    async def is_done(self) -> bool:
+        """Check whether the thread has reached a terminal status.
+
+        Returns:
+            ``True`` iff the thread's current status is terminal
+            (``TERMINATED`` or ``FAILED``).
+        """
+        ...
+
+    # ── Execution ────────────────────────────────────────────────
+
+    def run(self, *args: P.args, **kwargs: P.kwargs) -> asyncio.Future[T]:
+        """Enqueue a ``PromptRequest`` on the thread's work queue.
+
+        Args:
+            args: Positional arguments forwarded to the thread's prompt function.
+            kwargs: Keyword arguments forwarded to the thread's prompt function.
+
+        Returns:
+            A future resolved by the dispatcher once the cycle completes.
+
+        Ensures:
+            - One ``PromptRequest(args, kwargs, future)`` is appended to
+              the thread's FIFO work queue.
+            - Each call returns its own independent future.
+            - The returned future resolves with the result on success.
+            - The returned future rejects with the raised exception on error.
+            - The returned future rejects with ``CancelledError`` on
+              cooperative or hard cancel.
+
+        Raises:
+            ThreadNotFoundError: The thread is no longer registered.
+
+        Concurrency:
+            Synchronous enqueue via the coordinator; the cycle runs
+            later on the hosting worker's dispatcher.
+        """
+        ...
+
+    # ── Messaging ────────────────────────────────────────────────
+
+    async def notify(self, text: str) -> None:
+        """Deliver a side-channel message to this thread.
+
+        Best-effort: the thread decides whether and when to surface the
+        message. No cycle is started by this call.
+
+        Args:
+            text: Message body to route to the thread.
+
+        Raises:
+            ThreadNotFoundError: The thread is no longer registered.
+        """
+        ...
+
+    # ── Lifecycle ────────────────────────────────────────────────
+
+    async def pause(self) -> None:
+        """Pause the in-flight cycle at its next work boundary.
+
+        Ensures:
+            - The thread's pause signal is set.
+            - Queued work is not consumed until ``resume`` is called.
+
+        Raises:
+            ThreadNotFoundError: The thread is no longer registered.
+
+        Concurrency:
+            Idempotent.
+        """
+        ...
+
+    async def resume(self) -> None:
+        """Clear the pause signal so the executor continues.
+
+        Raises:
+            ThreadNotFoundError: The thread is no longer registered.
+
+        Concurrency:
+            Idempotent.
+        """
+        ...
+
+    async def cancel(self) -> None:
+        """Cooperatively cancel the in-flight cycle.
+
+        Ensures:
+            - The thread's cancel signal is set.
+            - The in-flight ``PromptRequest``'s future rejects with
+              ``CancelledError``.
+            - The thread remains registered and continues to accept new work.
+
+        Raises:
+            ThreadNotFoundError: The thread is no longer registered.
+
+        Concurrency:
+            No-op when no cycle is in flight.
+        """
+        ...
+
+    async def terminate(self) -> None:
+        """Schedule graceful termination behind currently-queued work.
+
+        Ensures:
+            - A ``TerminateAfterIdle`` marker is appended to the work queue.
+            - Items queued ahead of the marker run to completion.
+            - Items queued after the marker are rejected with ``CancelledError``.
+            - Status transitions to ``TERMINATED`` once the dispatcher reaches the marker.
+            - Subsequent ``run`` calls on this handle raise ``ThreadNotFoundError``.
+        """
+        ...
+
+    async def terminate_now(self) -> None:
+        """Tear the thread down immediately without draining the work queue.
+
+        Ensures:
+            - The in-flight task (if any) is cancelled.
+            - The in-flight ``PromptRequest``'s future rejects with ``CancelledError``.
+            - Every queued ``PromptRequest``'s future rejects with ``CancelledError``.
+            - The thread is removed from the coordinator before this call returns.
+        """
+        ...
+
+    # ── Forking ──────────────────────────────────────────────────
+
+    async def fork(self) -> ThreadHandle[P, T]:
+        """Fork into a new thread seeded with a copy of this thread's history.
+
+        Returns:
+            A new handle in ``NOT_STARTED`` state referring to the forked thread.
+
+        Raises:
+            ThreadNotFoundError: The thread is no longer registered.
+            NotImplementedError: This thread type does not support forking.
+        """
+        ...

--- a/spec/ai_functions/network/__init__.pyi
+++ b/spec/ai_functions/network/__init__.pyi
@@ -1,0 +1,52 @@
+"""Network layer — WebSocket RPC between coordinators and workers.
+
+This package provides the transport so :class:`~ai_functions.protocols.Coordinator`
+clients and remote :class:`~ai_functions.runtime.worker.LocalWorker` s can talk
+to a server-side :class:`~ai_functions.runtime.coordinator.InMemoryCoordinator`.
+
+- :class:`CoordinatorEndpoint` — server; fronts an in-memory coordinator
+  and accepts WebSocket connections.
+- :class:`CoordinatorClient` — client; implements :class:`Coordinator`
+  by proxying every method over the wire.
+- :class:`WireChannel` — symmetric bidirectional RPC machinery used by
+  both sides.
+- Frame models live in :mod:`ai_functions.network.wire`.
+
+See the module-level docstrings for design details.
+"""
+
+from __future__ import annotations
+
+from .channel import WireChannel
+from .client import CoordinatorClient
+from .endpoint import CoordinatorEndpoint
+from .wire import (
+    CallFrame,
+    ConnectionClosedError,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    ErrorFrame,
+    EventFrame,
+    Frame,
+    RemoteError,
+    ResultFrame,
+    Transport,
+    WireError,
+)
+
+__all__ = [
+    "CallFrame",
+    "ConnectionClosedError",
+    "CoordinatorClient",
+    "CoordinatorEndpoint",
+    "DEFAULT_HOST",
+    "DEFAULT_PORT",
+    "ErrorFrame",
+    "EventFrame",
+    "Frame",
+    "RemoteError",
+    "ResultFrame",
+    "Transport",
+    "WireChannel",
+    "WireError",
+]

--- a/spec/ai_functions/network/channel.pyi
+++ b/spec/ai_functions/network/channel.pyi
@@ -1,0 +1,283 @@
+"""WireChannel — symmetric RPC machinery shared by client and endpoint.
+
+A :class:`WireChannel` wraps a :class:`Transport` and provides:
+
+- ``call(method, **params)`` — initiate an outbound RPC; await the result.
+- ``send_event(event)`` — broadcast a server-initiated event (no response).
+- ``register(method_name, handler)`` — install an inbound dispatch handler.
+- ``on_event(callback)`` — subscribe to inbound event frames.
+
+Both sides of the wire use the same ``WireChannel`` class. The asymmetry
+between "client" and "endpoint" is entirely in which handlers each side
+registers (``coordinator.*`` on the endpoint; ``worker.*`` on a client
+that hosts a worker) — the channel itself is symmetric.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from types import TracebackType
+from typing import Any, Self
+
+from ..types import Event
+from .wire import Transport
+
+
+Handler = Callable[[dict[str, Any]], Awaitable[Any]]  # pyright: ignore[reportExplicitAny]
+"""Inbound call handler: takes parsed ``params``, returns a JSON-compatible value.
+
+Raising an exception produces an ``ErrorFrame`` in response; the
+exception's class name becomes the frame ``type``, ``str(exc)`` becomes
+the ``message``.
+"""
+
+EventCallback = Callable[[Event], None]
+"""Subscriber callback invoked for each inbound ``EventFrame``."""
+
+
+class WireChannel:
+    """Symmetric bidirectional JSON-frame RPC channel.
+
+    Owns one reader task that decodes incoming frames and routes them:
+
+    - ``call`` frames → dispatched via the handler table; response
+      frames written back.
+    - ``result`` / ``error`` frames → resolve / reject the matching
+      pending future in the outbound-calls map.
+    - ``event`` frames → fanned out to subscribed callbacks.
+
+    Args:
+        transport: The underlying duplex string channel.
+
+    Concurrency:
+        ``call``, ``send_event``, ``register``, and ``on_event`` are all
+        safe to invoke from multiple tasks concurrently.
+    """
+
+    def __init__(self, transport: Transport) -> None: ...
+
+    async def __aenter__(self) -> Self:
+        """Start the reader task and return ``self``."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Cancel the reader, close the transport, reject pending calls.
+
+        Args:
+            exc_type: Exception class raised inside the ``with`` block, if any.
+            exc: Exception instance raised inside the ``with`` block, if any.
+            tb: Traceback for the raised exception, if any.
+        """
+        ...
+
+    # ── Outbound ─────────────────────────────────────────────────────────────
+
+    async def call(self, method: str, **params: Any) -> Any:  # pyright: ignore[reportExplicitAny]
+        """Send a ``CallFrame`` and await the peer's response.
+
+        Args:
+            method: Dotted method name dispatched by the peer.
+            params: JSON-compatible keyword arguments.
+
+        Returns:
+            The JSON-compatible ``value`` field of the peer's
+            ``ResultFrame``.
+
+        Raises:
+            RemoteError: The peer replied with an ``ErrorFrame`` whose
+                ``type`` we can't rehydrate locally.
+            ThreadNotFoundError, ValueError, NotImplementedError: Re-raised
+                when the peer's ``type`` matches a known exception class.
+            ConnectionClosedError: The transport closed before the
+                response arrived.
+        """
+        ...
+
+    async def send_event(self, event: Event) -> None:
+        """Send an ``EventFrame`` to the peer; no response expected.
+
+        Args:
+            event: The event to broadcast.
+        """
+        ...
+
+    # ── Inbound ──────────────────────────────────────────────────────────────
+
+    def register(self, method: str, handler: Handler) -> None:
+        """Install a dispatch handler for inbound ``CallFrame`` s.
+
+        Args:
+            method: Dotted method name the peer will address.
+            handler: Called with the frame's ``params`` dict; its return
+                value becomes the ``ResultFrame.value``.
+
+        Raises:
+            ValueError: A handler is already registered for ``method``.
+        """
+        ...
+
+    def on_event(self, callback: EventCallback) -> Callable[[], None]:
+        """Subscribe to inbound ``EventFrame`` s.
+
+        Args:
+            callback: Invoked synchronously for each inbound event.
+
+        Returns:
+            An unsubscribe callable; calling it removes ``callback``
+            from the subscription list (idempotent).
+        """
+        ...
+
+    # ── State ────────────────────────────────────────────────────────────────
+
+    @property
+    def closed(self) -> bool:
+        """Whether the channel has been closed (either side).
+
+        After ``closed`` becomes ``True``, ``call`` and ``send_event``
+        raise ``ConnectionClosedError``.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Close the channel idempotently.
+
+        Cancels the reader task, rejects every pending outbound call
+        with :class:`ConnectionClosedError`, and closes the underlying
+        transport. Safe to call multiple times.
+        """
+        ...
+
+
+# ── Helpers / decorators for typed handler dispatch ──────────────────────────
+
+
+EVENT_ADAPTER: Any  # pyright: ignore[reportExplicitAny]
+"""TypeAdapter for the :class:`Event` tagged union; shared by client and endpoint."""
+
+
+def cloudpickle_b64(value: object) -> str:
+    """Cloudpickle-then-base64 helper for ``target`` / args / results on the wire.
+
+    Args:
+        value: Any cloudpicklable Python object.
+
+    Returns:
+        The base64 string representation of ``cloudpickle.dumps(value)``.
+    """
+    ...
+
+
+def unpickle_b64(blob: str) -> object:
+    """Inverse of :func:`cloudpickle_b64`.
+
+    Args:
+        blob: The base64 text produced by :func:`cloudpickle_b64`.
+
+    Returns:
+        The rehydrated Python object.
+    """
+    ...
+
+
+def event_to_dict(event: Event) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]
+    """Serialize an :class:`Event` (tagged union) to a wire-safe dict.
+
+    Args:
+        event: An event from the :class:`Event` tagged union.
+
+    Returns:
+        A JSON-compatible dict round-trippable through ``EVENT_ADAPTER``.
+    """
+    ...
+
+
+def rpc_method(
+    name: str,
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:  # pyright: ignore[reportExplicitAny]
+    """Tag a coroutine method as an RPC handler for the given wire name.
+
+    The decorated method must take exactly one positional argument
+    besides ``self``: a pydantic ``BaseModel`` subclass (the params
+    model). At bind time, the channel validates incoming
+    ``CallFrame.params`` against that model before calling the handler;
+    the handler's return value becomes the ``ResultFrame.value``.
+
+    Args:
+        name: Dotted wire method name (e.g. ``"coordinator.spawn"``).
+
+    Returns:
+        A decorator that stamps the wire name onto the handler.
+    """
+    ...
+
+
+def bind_handlers(
+    channel: WireChannel,
+    instance: object,
+    *,
+    rename: Callable[[str], str] | None = None,
+) -> None:
+    """Install every :func:`rpc_method`-decorated method on ``instance`` onto ``channel``.
+
+    For each decorated method, inspects the params annotation to locate
+    the pydantic model class, and registers a wrapper that:
+
+    - validates ``CallFrame.params`` via ``Model.model_validate`` before
+      dispatch;
+    - serializes pydantic results, lists, and enums on the way out;
+    - passes primitives / base64 strings / dicts through unchanged.
+
+    Args:
+        channel: The channel whose handler table receives the registrations.
+        instance: An object whose methods carry the :func:`rpc_method` tag.
+        rename: Optional function from the decorator's declared method
+            name to the name registered on the channel — for per-instance
+            namespacing (e.g. prefixing a worker id onto the
+            :class:`WorkerHandlers` tails).
+
+    Raises:
+        TypeError: A decorated method's signature isn't
+            ``(self, params: <BaseModel subclass>)``.
+    """
+    ...
+
+
+class WebsocketTransport:
+    """Adapt a ``websockets`` connection to the :class:`Transport` protocol.
+
+    Used for both sides: ``websockets.connect()`` returns a client
+    WebSocket; the object yielded by ``websockets.serve``'s handler is a
+    server WebSocket. Both expose the same ``send`` / ``recv`` / ``close``
+    API, so one adapter covers both.
+
+    Args:
+        ws: A ``websockets`` connection object.
+    """
+
+    def __init__(self, ws: Any) -> None: ...  # pyright: ignore[reportExplicitAny]
+
+    async def send(self, text: str) -> None:
+        """Send one frame's JSON text over the WebSocket.
+
+        Args:
+            text: The frame JSON to send.
+        """
+        ...
+
+    async def recv(self) -> str:
+        """Receive the next frame's JSON text from the WebSocket.
+
+        Returns:
+            The raw frame JSON as a string.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Close the WebSocket; idempotent."""
+        ...

--- a/spec/ai_functions/network/client.pyi
+++ b/spec/ai_functions/network/client.pyi
@@ -1,0 +1,491 @@
+"""CoordinatorClient — ``Coordinator`` implementation over a WireChannel.
+
+Connects to a :class:`CoordinatorEndpoint` over a single WebSocket and
+proxies every :class:`~ai_functions.protocols.Coordinator` method as an outbound
+RPC call. Also accepts *inbound* RPC calls from the endpoint when the
+client hosts a worker (the endpoint must reach the worker's adapter
+methods over the same connection).
+
+Usage::
+
+    client = await CoordinatorClient.connect("ws://localhost:9900/rpc")
+    worker = LocalWorker(client)
+    await worker.register()
+    handle = await worker.spawn_locally(my_fn)
+
+The client registers its hosted workers with the endpoint on first use;
+thereafter, inbound ``worker.*`` calls from the endpoint are dispatched
+to the matching ``LocalWorker`` instance via the shared ``WireChannel``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from types import TracebackType
+from typing import Any, Self, final
+
+from ..handle import ThreadHandle
+from ..protocols import Coordinator, OnEventCallback, Spawnable, Subscription
+from ..types import Event, EventId, EventKind, MessageId, ThreadId, ThreadInfo, ThreadStatus, WorkerId
+from .wire import Transport
+
+
+@final
+class CoordinatorClient(Coordinator):
+    """Remote :class:`~ai_functions.protocols.Coordinator` backed by a WebSocket.
+
+    Every ``Coordinator`` method issues a ``CallFrame`` over the
+    underlying :class:`WireChannel` and awaits a matching ``ResultFrame``
+    or ``ErrorFrame``. Events broadcast by the endpoint arrive as
+    ``EventFrame`` s and are delivered to subscribers registered via
+    :meth:`on`.
+
+    Workers hosted by this client (via ``LocalWorker(client)``) also
+    install their ``WorkerAdapter`` methods as inbound handlers on the
+    same channel, so the endpoint can route ``worker.spawn`` /
+    ``worker.submit`` / etc. back to them.
+
+    Args:
+        transport: An open duplex string channel. Prefer
+            :meth:`connect` for the common case; direct construction
+            is for tests that provide a mock transport.
+
+    Invariants:
+        Implements :class:`Coordinator`.
+    """
+
+    @classmethod
+    async def connect(cls, url: str) -> Self:
+        """Open a WebSocket to ``url`` and return a connected client.
+
+        Args:
+            url: ``ws://host:port/rpc`` URL of the coordinator endpoint.
+
+        Returns:
+            A connected ``CoordinatorClient`` ready for use.
+
+        Raises:
+            OSError: The connection could not be established.
+        """
+        ...
+
+    def __init__(self, transport: Transport) -> None: ...
+
+    async def close(self) -> None:
+        """Close the underlying channel; idempotent."""
+        ...
+
+    async def __aenter__(self) -> Self:
+        """Return ``self`` for use in a ``with`` block."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Close on context exit.
+
+        Args:
+            exc_type: Exception class raised inside the ``with`` block, if any.
+            exc: Exception instance raised inside the ``with`` block, if any.
+            tb: Traceback for the raised exception, if any.
+        """
+        ...
+
+    # ── Worker pool ──
+
+    async def register_worker(self, adapter: Any) -> None:  # pyright: ignore[reportExplicitAny]
+        """Register a worker with the remote coordinator.
+
+        Two-step: the adapter's methods are installed as inbound
+        handlers on the shared channel (so the endpoint can route
+        ``worker.*`` calls to the adapter), and a
+        ``coordinator.register_worker`` RPC is issued to tell the
+        endpoint this worker exists.
+
+        Args:
+            adapter: A :class:`~ai_functions.runtime.worker.WorkerAdapter`
+                hosted by this client process.
+
+        Raises:
+            ValueError: Already registered under the same ``worker_id``.
+        """
+        ...
+
+    async def deregister_worker(self, worker_id: WorkerId) -> None:
+        """Remove a worker from the remote pool; idempotent.
+
+        Args:
+            worker_id: Worker to remove.
+        """
+        ...
+
+    # ── Thread registry ──
+
+    async def register_thread(self, info: ThreadInfo) -> None:
+        """Register a thread with the remote coordinator.
+
+        Args:
+            info: Full snapshot of the thread's identity and host.
+
+        Raises:
+            ValueError: ``info.worker_id`` is not a registered worker.
+        """
+        ...
+
+    async def deregister_thread(self, thread_id: ThreadId) -> None:
+        """Remove ``thread_id`` from the remote registry; idempotent.
+
+        Args:
+            thread_id: Thread to remove.
+        """
+        ...
+
+    # ── Discovery ──
+
+    async def list_threads(self) -> list[ThreadInfo]:
+        """Return a snapshot of every registered thread.
+
+        Returns:
+            One :class:`ThreadInfo` per registered thread.
+        """
+        ...
+
+    async def get_thread_info(self, thread_id: ThreadId) -> ThreadInfo:
+        """Return the full info snapshot for ``thread_id``.
+
+        Args:
+            thread_id: Thread to look up.
+
+        Returns:
+            The :class:`ThreadInfo`.
+
+        Raises:
+            ThreadNotFoundError: No thread is registered under this id.
+        """
+        ...
+
+    def get_handle(self, thread_id: ThreadId) -> ThreadHandle[..., Any]:  # pyright: ignore[reportExplicitAny]
+        """Return a handle bound to this client for ``thread_id``.
+
+        Args:
+            thread_id: Thread to look up.
+
+        Returns:
+            A type-erased :class:`ThreadHandle`.
+        """
+        ...
+
+    async def get_thread_status(self, thread_id: ThreadId) -> ThreadStatus:
+        """Return the current status of ``thread_id``.
+
+        Args:
+            thread_id: Thread to query.
+
+        Returns:
+            The cached :class:`ThreadStatus`.
+
+        Raises:
+            ThreadNotFoundError: No thread is registered under this id.
+        """
+        ...
+
+    # ── Spawning ──
+
+    async def spawn[**P, T](
+        self,
+        target: Spawnable[P, T],
+        *,
+        seed_from: ThreadId | None = None,
+        seed_events: list[Event] | None = None,
+        worker_id: WorkerId | None = None,
+        thread_id: ThreadId | None = None,
+        thread_name: str | None = None,
+        parent_id: ThreadId | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> ThreadHandle[P, T]:
+        """Spawn a thread on the remote coordinator.
+
+        ``target`` is cloudpickled and shipped as a ``Binary`` param;
+        the endpoint unpickles and dispatches to the hosting worker.
+
+        Args:
+            target: Spawnable whose ``to_thread`` produces the live
+                instance on the hosting worker.
+            seed_from: Source thread whose event log is copied.
+            seed_events: Explicit event list to copy.
+            worker_id: Explicit worker selection; endpoint default if ``None``.
+            thread_id: Explicit id; one is minted if omitted.
+            thread_name: Human label for telemetry.
+            parent_id: Id of the parent thread.
+            metadata: Application metadata attached to the thread.
+
+        Returns:
+            A :class:`ThreadHandle` backed by this client.
+
+        Raises:
+            ValueError: Seeding / worker selection errors.
+            RemoteError: The endpoint rejected the spawn.
+        """
+        ...
+
+    # ── Cross-thread operations ──
+
+    def submit(
+        self,
+        thread_id: ThreadId,
+        *args: Any,  # pyright: ignore[reportExplicitAny]
+        **kwargs: Any,  # pyright: ignore[reportExplicitAny]
+    ) -> Awaitable[Any]:  # pyright: ignore[reportExplicitAny]
+        """Enqueue a ``PromptRequest`` on the remote thread's work queue.
+
+        Args and kwargs are cloudpickled together as a single ``Binary``
+        param. The returned awaitable resolves when the endpoint relays
+        the cycle result back.
+
+        Args:
+            thread_id: Thread to run.
+            args: Positional arguments forwarded to ``Thread.execute``.
+            kwargs: Keyword arguments forwarded to ``Thread.execute``.
+
+        Returns:
+            An awaitable that resolves with the cycle's typed result.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def notify(self, thread_id: ThreadId, text: str) -> None:
+        """Deliver a side-channel message to ``thread_id``.
+
+        Args:
+            thread_id: Thread receiving the message.
+            text: Message body.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def pause(self, thread_id: ThreadId) -> None:
+        """Set the pause signal on ``thread_id``.
+
+        Args:
+            thread_id: Thread to pause.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def resume(self, thread_id: ThreadId) -> None:
+        """Clear the pause signal on ``thread_id``.
+
+        Args:
+            thread_id: Thread to resume.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def cancel(self, thread_id: ThreadId) -> None:
+        """Cooperatively cancel the in-flight cycle on ``thread_id``.
+
+        Args:
+            thread_id: Thread to cancel.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def terminate(self, thread_id: ThreadId) -> None:
+        """Schedule graceful termination of ``thread_id``.
+
+        Args:
+            thread_id: Thread to terminate.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def terminate_now(self, thread_id: ThreadId) -> None:
+        """Tear ``thread_id`` down immediately.
+
+        Args:
+            thread_id: Thread to tear down.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def fork(self, thread_id: ThreadId) -> ThreadHandle[..., Any]:  # pyright: ignore[reportExplicitAny]
+        """Fork ``thread_id`` into a new thread seeded with its history.
+
+        Args:
+            thread_id: Thread to fork.
+
+        Returns:
+            A handle to the new forked thread.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+            NotImplementedError: The source thread does not support
+                forking.
+        """
+        ...
+
+    # ── Approvals ──
+
+    async def resolve_approval(
+        self,
+        thread_id: ThreadId,
+        approval_id: str,
+        decision: str,
+    ) -> None:
+        """Resolve a pending tool-approval request.
+
+        Args:
+            thread_id: Thread whose approval is being resolved.
+            approval_id: Id of the ``APPROVAL_REQUEST`` this resolves.
+            decision: Policy decision to return to the executor.
+        """
+        ...
+
+    # ── Events ──
+
+    def append_event(self, event: Event) -> None:
+        """Not supported on the client side.
+
+        Events originate at the endpoint's inner coordinator and are
+        broadcast to clients via :meth:`on`; clients cannot inject
+        events into the shared log.
+
+        Args:
+            event: Ignored.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        ...
+
+    async def get_events(
+        self,
+        thread_id: ThreadId,
+        since_id: EventId | None = None,
+        kinds: list[EventKind] | None = None,
+        limit: int | None = None,
+    ) -> list[Event]:
+        """Replay stored events for ``thread_id`` from the remote log.
+
+        Args:
+            thread_id: Thread whose events are being read.
+            since_id: Return only events appended strictly after this id.
+            kinds: Restrict to these event kinds; all kinds if ``None``.
+            limit: Return at most this many events; unbounded if ``None``.
+
+        Returns:
+            Events for ``thread_id`` matching the filters, oldest first.
+        """
+        ...
+
+    async def new_message_id(self) -> MessageId:
+        """Mint a fresh message id on the endpoint.
+
+        Returns:
+            A freshly minted message id.
+        """
+        ...
+
+    async def copy_events(
+        self,
+        source_id: ThreadId,
+        target_id: ThreadId,
+        until_event_id: EventId | None = None,
+    ) -> None:
+        """Copy events from one thread to another on the endpoint.
+
+        Args:
+            source_id: Thread whose events are read.
+            target_id: Thread whose log receives rewritten copies.
+            until_event_id: Copy events up to and including this id;
+                copy the entire current history when ``None``.
+
+        Raises:
+            ThreadNotFoundError: Either thread is not registered.
+            ValueError: ``until_event_id`` does not match any source event.
+        """
+        ...
+
+    # ── Subscriptions ──
+
+    def on(
+        self,
+        callback: OnEventCallback,
+        *,
+        thread_id: ThreadId | None = None,
+        kinds: list[EventKind] | None = None,
+    ) -> Subscription:
+        """Subscribe to events broadcast by the endpoint.
+
+        The client does not maintain a durable event log — subscriptions
+        receive events broadcast over the wire after registration.
+
+        Args:
+            callback: Sink invoked for each matching event.
+            thread_id: Restrict to this thread if set.
+            kinds: Restrict to these event kinds if set.
+
+        Returns:
+            A :class:`Subscription` whose ``unsubscribe`` tears down
+            this registration.
+        """
+        ...
+
+    # ── Rate limiting ──
+
+    async def is_paused(self, thread_id: ThreadId) -> bool:
+        """Return whether ``thread_id`` is paused on the endpoint.
+
+        Args:
+            thread_id: Thread to query.
+
+        Returns:
+            True iff the thread is paused at this instant.
+        """
+        ...
+
+    def wait_until_unpaused(self, thread_id: ThreadId) -> Awaitable[None]:
+        """Await until ``thread_id`` is unpaused on the endpoint.
+
+        Args:
+            thread_id: Thread whose pause signal to watch.
+
+        Returns:
+            An awaitable that resolves when the thread is unpaused.
+        """
+        ...
+
+
+class WorkerHandlers:
+    """Bundled inbound ``worker.<wid>.*`` RPC handlers for one worker adapter.
+
+    Installed on the shared channel by
+    :meth:`CoordinatorClient.register_worker`, which uses
+    :func:`~ai_functions.network.channel.bind_handlers` with a ``rename``
+    callback so the decorator's ``worker.<op>`` tag expands to
+    ``worker.<wid>.<op>`` — multiple workers hosted behind the same
+    client share one channel without colliding.
+
+    Args:
+        adapter: The :class:`~ai_functions.runtime.worker.WorkerAdapter` whose
+            methods every decorated handler forwards to.
+    """
+
+    def __init__(self, adapter: Any) -> None: ...  # pyright: ignore[reportExplicitAny]

--- a/spec/ai_functions/network/endpoint.pyi
+++ b/spec/ai_functions/network/endpoint.pyi
@@ -1,0 +1,164 @@
+"""CoordinatorEndpoint — WebSocket server fronting an in-memory coordinator.
+
+A :class:`CoordinatorEndpoint` accepts WebSocket connections from
+:class:`CoordinatorClient` instances. Each connection gets its own
+:class:`WireChannel`; the endpoint registers ``coordinator.*`` handlers
+on every channel so clients can call every
+:class:`~ai_functions.protocols.Coordinator` method over the wire.
+
+When a client registers a worker (via ``coordinator.register_worker``),
+the endpoint builds a per-channel ``_RemoteWorkerAdapter`` shim that
+translates ``WorkerAdapter`` calls (from the inner in-memory coordinator)
+into outbound ``worker.*`` RPC calls on the originating channel. The
+shim is registered with the inner coordinator's worker pool, so routing
+from other threads / other workers transparently reaches the remote
+process.
+
+Events appended to the inner coordinator are fanned out to every
+connected channel as :class:`EventFrame` broadcasts.
+
+Transport note:
+    The default server uses ``websockets.serve``. A FastAPI / Starlette
+    app with a WebSocket route can be added later by adapting the
+    channel's :class:`Transport` to Starlette's WebSocket API; all the
+    RPC logic is transport-agnostic.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Any, Self, final
+
+from ..protocols import Coordinator
+from ..types import WorkerId
+from .channel import WireChannel
+
+
+@final
+class CoordinatorEndpoint:
+    """WebSocket server fronting an :class:`InMemoryCoordinator`.
+
+    Usage::
+
+        endpoint = CoordinatorEndpoint()
+        await endpoint.serve(host="127.0.0.1", port=9900)
+
+        # or as a context manager:
+        async with CoordinatorEndpoint() as endpoint:
+            await endpoint.start(host="127.0.0.1", port=9900)
+            # endpoint.url → "ws://127.0.0.1:9900/rpc"
+            ...
+            await endpoint.stop()
+
+    Args:
+        coordinator: Pre-built inner coordinator; a fresh
+            :class:`InMemoryCoordinator` is constructed when ``None``.
+
+    Ensures:
+        - On :meth:`serve` / :meth:`start`, the endpoint accepts
+          WebSocket connections and multiplexes RPC calls + events over
+          each one.
+        - On :meth:`stop`, every connected channel is closed, worker
+          shims are deregistered from the inner coordinator, and the
+          server socket is released.
+    """
+
+    def __init__(self, coordinator: Coordinator | None = None) -> None: ...
+
+    @property
+    def coordinator(self) -> Coordinator:
+        """The inner coordinator this endpoint fronts."""
+        ...
+
+    @property
+    def url(self) -> str:
+        """The ``ws://host:port/rpc`` URL of the running server.
+
+        Raises:
+            RuntimeError: The server is not running.
+        """
+        ...
+
+    async def start(self, *, host: str = ..., port: int = ...) -> None:
+        """Start accepting connections in the background.
+
+        Args:
+            host: Bind address; defaults to :data:`DEFAULT_HOST`.
+            port: Bind port; defaults to :data:`DEFAULT_PORT`.
+
+        Ensures:
+            - The server is listening on ``host:port``.
+            - :attr:`url` is available.
+        """
+        ...
+
+    async def stop(self) -> None:
+        """Stop accepting new connections and close existing channels.
+
+        Ensures:
+            - No new connections are accepted.
+            - Every connected channel is closed; remote workers are
+              deregistered from the inner coordinator.
+            - :meth:`start` / :meth:`serve` may be called again.
+
+        Concurrency:
+            Idempotent.
+        """
+        ...
+
+    async def serve(self, *, host: str = ..., port: int = ...) -> None:
+        """Start the server and block until cancelled.
+
+        Convenience for long-running server processes::
+
+            asyncio.run(CoordinatorEndpoint().serve())
+
+        Args:
+            host: Bind address; defaults to :data:`DEFAULT_HOST`.
+            port: Bind port; defaults to :data:`DEFAULT_PORT`.
+        """
+        ...
+
+    async def __aenter__(self) -> Self:
+        """Return ``self`` for use in an ``async with`` block."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Stop the server on context exit.
+
+        Args:
+            exc_type: Exception class raised inside the ``with`` block, if any.
+            exc: Exception instance raised inside the ``with`` block, if any.
+            tb: Traceback for the raised exception, if any.
+        """
+        ...
+
+
+class CoordinatorHandlers:
+    """Bundled inbound ``coordinator.*`` RPC handlers for a single channel.
+
+    One instance per connected client. Each public method is decorated
+    with :func:`~ai_functions.network.channel.rpc_method` so that
+    :func:`~ai_functions.network.channel.bind_handlers` can install every
+    ``coordinator.<op>`` handler on the channel at once.
+
+    Attributes:
+        hosted_workers: Maps :class:`WorkerId` → the remote worker
+            adapter shim the endpoint built for this client. Populated
+            by ``register_worker``, cleared on channel close.
+
+    Args:
+        coord: The inner in-memory coordinator this endpoint fronts.
+        channel: The per-connection :class:`WireChannel` (used to
+            build outbound ``worker.*`` RPC shims when a worker is
+            registered).
+    """
+
+    hosted_workers: dict[WorkerId, Any]  # pyright: ignore[reportExplicitAny]
+
+    def __init__(self, coord: Coordinator, channel: WireChannel) -> None: ...

--- a/spec/ai_functions/network/wire.pyi
+++ b/spec/ai_functions/network/wire.pyi
@@ -1,0 +1,201 @@
+"""Wire protocol — pydantic frames for the Coordinator/Worker network layer.
+
+The network layer is a symmetric, bidirectional RPC channel over a single
+WebSocket. Either peer (client or endpoint) may initiate a call; the
+other answers. Events broadcast from endpoint to client are the same
+frame shape with no correlation expected.
+
+Frames are discriminated on ``kind``:
+
+- ``call``  — request: method name + JSON params. Awaits a ``result``
+  or ``error`` frame with matching ``id``.
+- ``result`` — success response; carries a JSON value.
+- ``error``  — failure response; carries an error type + message.
+- ``event``  — server-initiated event broadcast; no response expected.
+
+A single ``Binary`` field is used for cloudpickle payloads (Spawnables,
+run-cycle args/kwargs/results) which cannot be JSON-encoded.
+
+Encoding: ``frame.model_dump_json()``
+Decoding: ``TypeAdapter(Frame).validate_json(raw)``
+
+The wire layer is transport-agnostic: any async duplex string channel
+satisfying :class:`Transport` is acceptable. The default implementation
+uses ``websockets``; FastAPI / Starlette WebSockets can be plugged in
+via a thin adapter.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+DEFAULT_HOST: str = "127.0.0.1"
+"""Default host for :class:`CoordinatorEndpoint` and :class:`CoordinatorClient`."""
+
+DEFAULT_PORT: int = 9900
+"""Default port for :class:`CoordinatorEndpoint` and :class:`CoordinatorClient`."""
+
+
+# ── Binary escape type ───────────────────────────────────────────────────────
+
+
+Binary = Annotated[bytes, ...]
+"""Binary field encoded as base64 in JSON; accepts raw bytes on construction.
+
+Used for cloudpickle-serialized spawnables and prompt args / kwargs /
+results — payloads that can't round-trip through JSON natively.
+"""
+
+
+# ── Frames ────────────────────────────────────────────────────────────────────
+
+
+class CallFrame(BaseModel):
+    """Outbound RPC request.
+
+    Fields:
+        kind: Discriminator (always ``"call"``).
+        id: Correlation id chosen by the caller; echoed in the matching
+            ``result`` or ``error`` frame.
+        method: Dotted method name the peer should dispatch
+            (e.g. ``"coordinator.spawn"``, ``"worker.submit"``).
+        params: JSON-compatible keyword arguments. Non-JSON values
+            (cloudpickle blobs) are carried as ``Binary`` base64 fields
+            inside this dict at method-specific keys.
+    """
+
+    kind: Literal["call"]
+    id: str
+    method: str
+    params: dict[str, Any]  # pyright: ignore[reportExplicitAny]
+
+
+class ResultFrame(BaseModel):
+    """Successful RPC response.
+
+    Fields:
+        kind: Discriminator (always ``"result"``).
+        id: Matches the ``id`` of the originating ``CallFrame``.
+        value: JSON-compatible return value; may contain ``Binary``
+            blobs at method-specific keys.
+    """
+
+    kind: Literal["result"]
+    id: str
+    value: Any  # pyright: ignore[reportExplicitAny]
+
+
+class ErrorFrame(BaseModel):
+    """Failed RPC response.
+
+    Fields:
+        kind: Discriminator (always ``"error"``).
+        id: Matches the ``id`` of the originating ``CallFrame``.
+        type: Exception class name (e.g. ``"ThreadNotFoundError"``,
+            ``"ValueError"``). Used on the caller side to reconstruct a
+            typed exception when possible; otherwise surfaced as
+            :class:`RemoteError`.
+        message: Human-readable error description.
+    """
+
+    kind: Literal["error"]
+    id: str
+    type: str
+    message: str
+
+
+class EventFrame(BaseModel):
+    """Broadcast from endpoint to client.
+
+    Fields:
+        kind: Discriminator (always ``"event"``).
+        event: One :class:`ai_functions.types.Event` pydantic model, serialized
+            in place (the wire layer calls ``model_dump`` / ``model_validate``
+            on the tagged union).
+
+    No correlation id — events are fire-and-forget from the sender's POV.
+    """
+
+    kind: Literal["event"]
+    event: Any  # pyright: ignore[reportExplicitAny]  # ai_functions.types.Event union
+
+
+Frame = Annotated[
+    CallFrame | ResultFrame | ErrorFrame | EventFrame,
+    Field(discriminator="kind"),
+]
+"""Discriminated union of every frame shape that crosses the wire."""
+
+
+# ── Transport protocol ───────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class Transport(Protocol):
+    """Thin async duplex string channel.
+
+    Both sides of the wire layer talk to a ``Transport``. The default
+    implementation wraps a ``websockets`` client / server socket; a
+    FastAPI / Starlette WebSocket can be adapted to this protocol with a
+    trivial wrapper (both expose ``send`` / ``recv`` with different
+    method names).
+
+    Implementations must be safe to call concurrently for ``send`` and
+    ``recv`` from different tasks (full-duplex).
+    """
+
+    async def send(self, text: str) -> None:
+        """Send one frame's serialized JSON over the wire.
+
+        Args:
+            text: The ``frame.model_dump_json()`` output.
+        """
+        ...
+
+    async def recv(self) -> str:
+        """Receive one frame's serialized JSON from the wire.
+
+        Returns:
+            The next frame's JSON text, as sent by the peer.
+
+        Raises:
+            ConnectionClosedError: The peer closed the connection.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Close the underlying connection idempotently."""
+        ...
+
+
+# ── Error hierarchy ──────────────────────────────────────────────────────────
+
+
+class WireError(Exception):
+    """Base class for wire-layer errors."""
+
+
+class RemoteError(WireError):
+    """A peer returned an ``ErrorFrame`` whose ``type`` we cannot rehydrate.
+
+    Attributes:
+        remote_type (str): The ``type`` field from the ErrorFrame — the
+            peer's exception class name.
+        message (str): The ``message`` field from the ErrorFrame.
+
+    Args:
+        remote_type: The ``type`` field from the ErrorFrame.
+        message: The ``message`` field from the ErrorFrame.
+    """
+
+    remote_type: str
+    message: str
+
+    def __init__(self, remote_type: str, message: str) -> None: ...
+
+
+class ConnectionClosedError(WireError):
+    """The peer connection closed before a pending call resolved."""

--- a/spec/ai_functions/protocols.pyi
+++ b/spec/ai_functions/protocols.pyi
@@ -1,0 +1,907 @@
+"""Coordinator contract and cross-thread extension points.
+
+This module defines the three user-facing protocols of the system:
+
+- :class:`Thread` — the live, runnable instance contract a worker drives.
+- :class:`Spawnable` — factory for a ``Thread``; what users pass to
+  ``coordinator.spawn`` or ``worker.spawn_locally``.
+- :class:`Coordinator` — the authoritative registry, event log, message
+  router, and cross-worker dispatcher. Every user-facing operation on a
+  thread routes through a coordinator.
+
+The ``Worker`` / ``WorkerAdapter`` story lives in ``ai_functions.runtime.worker``
+because it is an execution-engine concern; users rarely interact with
+it directly beyond constructing a ``LocalWorker``.
+
+Invariants:
+    I1 — every registered thread has exactly one host worker, reachable
+    via the adapter stored in the coordinator's routing table.
+
+    I5 — the worker's dispatcher is the sole emitter of lifecycle events
+    (``STARTED``, ``COMPLETED``, ``CANCELLED``, ``FAILED``, ``RESULT``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Awaitable, Protocol, runtime_checkable
+
+from strands.interrupt import Interrupt
+from strands.types.interrupt import InterruptResponseContent
+
+from .types import (
+    Event,
+    EventId,
+    EventKind,
+    InputShape,
+    MessageId,
+    Policy,
+    ThreadContext,
+    ThreadId,
+    ThreadInfo,
+    ThreadStatus,
+    WorkerId,
+)
+
+if TYPE_CHECKING:
+    from .handle import ThreadHandle
+    from .runtime.worker import WorkerAdapter
+
+
+# ── Callback protocols ──
+
+class OnEventCallback(Protocol):
+    """Sink bound to ``Coordinator.append_event`` for a single event."""
+
+    def __call__(self, event: Event) -> None:
+        """Forward one event to the coordinator's append path.
+
+        Args:
+            event: The event to deliver.
+
+        Ensures:
+            ``event`` reaches ``Coordinator.append_event``.
+        """
+        ...
+
+
+@runtime_checkable
+class Subscription(Protocol):
+    """Handle returned by ``Coordinator.on`` that tears down its own registration.
+
+    Also usable as a context manager: exiting the ``with`` block calls ``unsubscribe``
+    unconditionally, even on exception.
+    """
+
+    def unsubscribe(self) -> None:
+        """Tear down this subscription so its callback receives no further events.
+
+        Ensures:
+            No further invocation of the registered callback for events appended after
+            this call.
+
+        Concurrency:
+            Idempotent.
+        """
+        ...
+
+    def __enter__(self) -> Subscription:
+        """Return ``self`` for use in a ``with`` block."""
+        ...
+
+    def __exit__(self, *exc: Any) -> None:
+        """Call ``unsubscribe`` on context exit.
+
+        Args:
+            exc: Exception info tuple from the context manager protocol.
+        """
+        ...
+
+
+class OnInterruptCallback(Protocol):
+    """Handler for a batch of executor-raised interrupts (e.g., tool approvals)."""
+
+    async def __call__(self, interrupts: list[Interrupt]) -> list[InterruptResponseContent]:
+        """Resolve one batch of Strands interrupts to decision responses.
+
+        Args:
+            interrupts: One ``strands.interrupt.Interrupt`` per pending approval, in
+                executor order.
+
+        Returns:
+            One ``InterruptResponseContent`` per interrupt, in the same order; each
+            carrying the matching ``interruptId``.
+
+        Emits:
+            APPROVAL_REQUEST (one per entry in ``interrupts``).
+
+        Concurrency:
+            Awaited inline by the executor; the dispatcher sees no event during the wait.
+        """
+        ...
+
+
+# ── Thread — a live, runnable thread instance ──
+
+@runtime_checkable
+class Thread[**P, T](Protocol):
+    """A live, runnable thread instance the worker drives.
+
+    See Also:
+        :class:`ThreadStatus`.
+    """
+
+    @property
+    def name(self) -> str:
+        """Human-readable name of the thread, used for telemetry and error attribution.
+
+        Need not be unique across threads.
+
+        Concurrency:
+            Synchronous and side-effect-free.
+        """
+        ...
+
+    async def execute(self, ctx: ThreadContext, *args: P.args, **kwargs: P.kwargs) -> T:
+        """Start one cycle against ``ctx`` with typed arguments and return its result.
+
+        Args:
+            ctx: Freshly built per-cycle context; never reused across cycles.
+            args: Positional arguments forwarded from ``ThreadHandle.run``.
+            kwargs: Keyword arguments forwarded from ``ThreadHandle.run``.
+
+        Returns:
+            The typed cycle result on natural completion.
+
+        Requires:
+            ``ctx`` is a fresh context built by the worker for this cycle.
+
+        Obligations:
+            - At each work boundary, raise ``CancelledError`` if
+              ``ctx.cancel_signal`` is set.
+            - At each work boundary, await ``ctx.pause_signal`` if set.
+            - Invoke ``ctx.on_interrupt`` inline when the executor surfaces interrupts.
+            - Observe any side-channel messages delivered via
+              :meth:`notify` at a safe boundary of its choosing;
+              threads that don't care about injections may ignore them.
+
+        Raises:
+            asyncio.CancelledError: ``ctx.cancel_signal`` was set at a work boundary.
+        """
+        ...
+
+    async def notify(self, text: str) -> None:
+        """Deliver a side-channel message into this thread's stream.
+
+        Best-effort notification: the thread decides whether and when to
+        surface the message. Typically threads buffer the text internally
+        and drain it at a safe boundary inside their next (or in-flight)
+        :meth:`execute` cycle. Calling ``notify`` does NOT start a
+        cycle; an idle thread remains idle. A running thread may observe
+        the message mid-cycle if it chooses.
+
+        Default implementation is a no-op — threads that ignore injected
+        messages need not override. Concrete implementations (e.g.
+        ``AIThread``) maintain their own buffer.
+
+        Args:
+            text: Message body delivered by the worker or an external sender.
+
+        Ensures:
+            - No new cycle is started by this call.
+            - Observation timing is the thread's choice.
+
+        Concurrency:
+            Awaited inline by the caller (worker delivery path). Must not
+            block on network I/O.
+        """
+        ...
+
+    def serialize_result(self, result: T) -> str:
+        """Encode ``result`` as a string for storage in a ``ResultEvent``.
+
+        Args:
+            result: The typed cycle result to serialize.
+
+        Returns:
+            A string representation of ``result`` that
+            :meth:`deserialize_result` can round-trip.
+
+        Ensures:
+            ``deserialize_result(serialize_result(result))`` is equal to ``result``.
+
+        Concurrency:
+            Synchronous and side-effect-free.
+        """
+        ...
+
+    def deserialize_result(self, payload: str) -> T:
+        """Recover a result from the string stored in a ``ResultEvent``.
+
+        Args:
+            payload: Value previously produced by :meth:`serialize_result`.
+
+        Returns:
+            The deserialized result of type ``T``.
+
+        Raises:
+            AIFunctionError: The payload is malformed or cannot be
+                decoded as ``T``.
+        """
+        ...
+
+    async def fork(self) -> Spawnable[P, T]:
+        """Return a ``Spawnable`` that, when instantiated, resumes this thread's state.
+
+        The coordinator uses this to build the forked thread's live
+        instance. The returned spawnable MUST be safe to pass to
+        :meth:`Coordinator.spawn` with ``seed_from=source_id``; the
+        coordinator then seeds the new thread's event log before the
+        dispatcher starts.
+
+        For threads whose only state is the event log (e.g. :class:`AIThread`)
+        this is a one-liner — the original template is stateless and
+        reusing it is correct. Threads with external state (a CLI
+        subprocess, a remote session, a checkpointed workspace) must
+        return a spawnable that carries the resumption payload so that
+        :meth:`Spawnable.to_thread` produces a live instance equivalent
+        to ``self`` at the moment of the call.
+
+        Returns:
+            A spawnable whose :meth:`Spawnable.to_thread` produces a
+            fresh live instance equivalent to ``self`` — the event log
+            then diverges from the parent via the dispatcher.
+
+        Ensures:
+            The returned spawnable's ``to_thread()`` produces a live
+            instance whose non-event state (if any) is equivalent to
+            ``self``'s at the moment ``fork`` was called.
+
+        Raises:
+            NotImplementedError: This thread type does not support
+                forking.
+        """
+        ...
+
+    async def teardown(self) -> None:
+        """Release any resources this thread holds; called on termination.
+
+        Invoked once by :meth:`Coordinator.terminate` (after the dispatcher
+        drains its queue and reaches the termination marker) and by
+        :meth:`Coordinator.terminate_now` (after the in-flight task is
+        cancelled). No cycle is in flight at the time of the call; no
+        further :meth:`execute` will be invoked on this instance.
+
+        Threads with no external state (e.g. :class:`AIThread`) may leave
+        the default no-op implementation. Threads owning a subprocess,
+        network connection, file handle, or remote session should close
+        them here. Threads that buffer injected messages should drop the
+        buffer here.
+
+        Ensures:
+            - Resources owned by this thread are released.
+            - Failures are the thread's responsibility; raising from
+              ``teardown`` is allowed but will surface as an unhandled
+              exception in the dispatcher's teardown path.
+
+        Concurrency:
+            Awaited inline by the worker during teardown; not racing with
+            ``execute``.
+        """
+        ...
+
+
+# ── Spawnable — factory for a Thread ──
+
+@runtime_checkable
+class Spawnable[**P, T](Protocol):
+    """Factory for a ``Thread``; input to ``coordinator.spawn`` / ``worker.spawn_locally``."""
+
+    def to_thread(self) -> Thread[P, T]:
+        """Produce a fresh live ``Thread`` bound to a single spawn."""
+        ...
+
+    @property
+    def input_shape(self) -> InputShape:
+        """Coarse classification of this spawnable's ``execute`` input signature.
+
+        The coordinator stores this on :class:`ThreadInfo` at spawn time
+        so tools (and clients) can discover which threads are chat-style
+        peers. See :class:`InputShape` for the enum values.
+        """
+        ...
+
+
+# ── Coordinator — broker, registry, event log, and cross-worker router ──
+
+@runtime_checkable
+class Coordinator(Protocol):
+    """The authoritative broker of the system: registry + event log + router.
+
+    The coordinator is the sole user-facing object for operations that
+    take a ``thread_id``. It holds:
+
+    - A registry of workers (``dict[WorkerId, WorkerAdapter]``).
+    - A registry of threads (``dict[ThreadId, ThreadInfo]``), each
+      carrying a ``worker_id`` the coordinator uses to route operations
+      to the hosting worker's adapter.
+    - The durable event log, through which ``append_event`` writes and
+      ``get_events`` / ``on`` subscribers read.
+    - Pause signals per-thread, driven by ``TOKEN_USAGE`` events.
+    - The approval-decision routing path (approvals are events).
+
+    Cross-process distribution is implemented by a ``RemoteCoordinator``
+    client that proxies the full protocol over a network transport to
+    a :class:`~ai_functions.network.CoordinatorEndpoint` fronting an in-memory
+    coordinator on the server. Clients that connect to the same endpoint
+    observe the same threads, events, and workers.
+
+    Invariants:
+        I1, I2, I3, I5, I11, I12.
+
+        I11 (side-effect isolation): once :meth:`append_event` has
+        durably stored an event, any failure in its side effects
+        (status caching, subscriber fan-out, rate-limit hooks) MUST
+        NOT propagate to the caller. The caller is typically a worker
+        dispatcher task, and propagating would kill the thread and
+        cause downstream ``handle.run(...)`` futures to hang. Failures
+        must be logged and swallowed; subsequent side effects still run.
+
+        I12 (liveness under failure): a :class:`Coordinator` MUST
+        guarantee that every pending operation (a ``handle.run`` future,
+        a pending ``spawn``, etc.) eventually resolves — either
+        successfully or by raising — even if the backing transport,
+        worker, or internal task dies. No code path may silently
+        orphan a caller's await. Concretely, if a worker's dispatcher
+        or a wire connection fails, the coordinator is responsible for
+        failing pending futures with the root exception (or a clear
+        surrogate like ``ConnectionClosedError``).
+    """
+
+    # ── Worker pool ──
+
+    async def register_worker(self, adapter: WorkerAdapter) -> None:
+        """Register a worker with this coordinator.
+
+        Called by a worker at construction time. The coordinator records
+        the adapter keyed by ``adapter.worker_id`` and uses it to route
+        operations for any thread whose ``info.worker_id`` matches.
+
+        Args:
+            adapter: The adapter the coordinator will invoke for every
+                operation on threads hosted by this worker.
+
+        Ensures:
+            Subsequent :meth:`register_thread` calls citing this worker
+            will find an adapter to route to.
+
+        Raises:
+            ValueError: A worker is already registered under the same
+                ``worker_id``.
+        """
+        ...
+
+    async def deregister_worker(self, worker_id: WorkerId) -> None:
+        """Remove a worker from the pool.
+
+        All threads hosted by that worker are implicitly removed from
+        the routing table as part of the worker's own ``close`` flow;
+        this method should be called after the worker's threads are
+        already terminated.
+
+        Args:
+            worker_id: Id of the worker to remove.
+
+        Concurrency:
+            Idempotent; removing an unknown id is a no-op.
+        """
+        ...
+
+    # ── Thread registry ──
+
+    async def register_thread(self, info: ThreadInfo) -> None:
+        """Register a thread with this coordinator.
+
+        Called by the hosting worker after allocating the thread's
+        state but before starting its dispatcher. ``info.worker_id``
+        must point at a worker already registered via
+        :meth:`register_worker`.
+
+        Args:
+            info: Full snapshot of the thread's identity and host.
+
+        Ensures:
+            - Subsequent operations on ``info.thread_id`` route to the
+              worker identified by ``info.worker_id``.
+            - :meth:`list_threads` and :meth:`get_thread_info` return
+              this info.
+            - :meth:`notify`, :meth:`submit`, and peers find the
+              thread.
+
+        Raises:
+            ValueError: ``info.worker_id`` is not a registered worker.
+        """
+        ...
+
+    async def deregister_thread(self, thread_id: ThreadId) -> None:
+        """Remove ``thread_id`` from the registry.
+
+        Called by the hosting worker on thread teardown. Events for the
+        thread remain in the log for audit and replay.
+
+        Args:
+            thread_id: Id of the thread being removed.
+
+        Concurrency:
+            Idempotent; removing an unknown id is a no-op.
+        """
+        ...
+
+    # ── Discovery ──
+
+    async def list_threads(self) -> list[ThreadInfo]:
+        """Return a snapshot of every registered thread.
+
+        Returns:
+            One :class:`ThreadInfo` per registered thread, order
+            implementation-defined.
+        """
+        ...
+
+    async def get_thread_info(self, thread_id: ThreadId) -> ThreadInfo:
+        """Return the full info snapshot for ``thread_id``.
+
+        Args:
+            thread_id: Thread to look up.
+
+        Returns:
+            The :class:`ThreadInfo` for this thread.
+
+        Raises:
+            ThreadNotFoundError: No thread is registered under this id.
+        """
+        ...
+
+    def get_handle(self, thread_id: ThreadId) -> ThreadHandle[..., Any]:
+        """Return a handle bound to this coordinator for ``thread_id``.
+
+        Args:
+            thread_id: Thread to look up.
+
+        Returns:
+            A typed-erased :class:`ThreadHandle`. Callers who know the
+            expected ``P, T`` can annotate at the call site to narrow.
+
+        Raises:
+            ThreadNotFoundError: No thread is registered under this id.
+        """
+        ...
+
+    async def get_thread_status(self, thread_id: ThreadId) -> ThreadStatus:
+        """Return the current status of ``thread_id``.
+
+        Served from the coordinator's own registry, which tracks status
+        by subscribing to lifecycle events emitted by the hosting
+        worker's dispatcher.
+
+        Args:
+            thread_id: Thread to query.
+
+        Returns:
+            The cached :class:`ThreadStatus` for this thread.
+
+        Raises:
+            ThreadNotFoundError: No thread is registered under this id.
+        """
+        ...
+
+    # ── Spawning ──
+
+    async def spawn[**P, T](
+        self,
+        target: Spawnable[P, T],
+        *,
+        seed_from: ThreadId | None = None,
+        seed_events: list[Event] | None = None,
+        worker_id: WorkerId | None = None,
+        thread_id: ThreadId | None = None,
+        thread_name: str | None = None,
+        parent_id: ThreadId | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> ThreadHandle[P, T]:
+        """Create a new thread on a registered worker, optionally pre-seeded.
+
+        Worker selection:
+
+        - If ``worker_id`` is given, the named worker hosts the thread;
+          raises if no such worker is registered.
+        - Otherwise, the coordinator selects one by its default policy
+          (implementation-defined; the in-memory coordinator picks the
+          first registered worker).
+
+        ``target`` must be cloudpickle-safe if the coordinator may
+        dispatch to a remote worker. Clients that need to spawn a
+        non-picklable thread must go through
+        :meth:`LocalWorker.spawn_locally` directly on a local worker —
+        that is the in-process escape hatch and never crosses a wire.
+
+        Seeding (optional):
+
+        - ``seed_from=source_id``: copy every event from the source
+          thread's log into the new thread's log, rewriting
+          ``thread_id`` and minting fresh event ids. Used for forking
+          (see :meth:`fork`) and for resuming a thread from another
+          live thread on the same coordinator.
+        - ``seed_events=[...]``: rehydrate from an explicit event list
+          — for example, a persisted snapshot.
+        - At most one of ``seed_from`` / ``seed_events`` may be given.
+          Passing neither produces a fresh thread with an empty log.
+
+        Ordering (atomic w.r.t. external observers):
+
+        1. Mint ``thread_id`` if not provided.
+        2. Seed the event log bucket (when applicable).
+        3. Register the ``ThreadInfo`` — the thread now appears in
+           :meth:`list_threads`, :meth:`get_events` returns the seeded
+           log, and peers may ``submit`` / ``notify``.
+        4. Call ``WorkerAdapter.spawn`` on the hosting worker, which
+           allocates per-thread state and starts the dispatcher.
+
+        External observers never see a registered thread with an empty
+        log when seeding was requested: the seed is always in place
+        before registration completes.
+
+        Args:
+            target: Spawnable whose ``to_thread`` produces the live instance.
+            seed_from: Source thread whose event log is copied onto the
+                new thread. Mutually exclusive with ``seed_events``.
+            seed_events: Explicit event list copied onto the new
+                thread's log. Mutually exclusive with ``seed_from``.
+            worker_id: Explicit worker selection; coordinator-default if ``None``.
+            thread_id: Explicit id; one is minted if omitted.
+            thread_name: Human label for telemetry.
+            parent_id: Id of the parent thread for hierarchical rollup.
+                No magic default — callers who want ``seed_from`` to
+                also be the parent must pass it explicitly.
+            metadata: Application metadata attached to the thread.
+
+        Returns:
+            A ``ThreadHandle`` whose coordinator is ``self``.
+
+        Raises:
+            ValueError: Both ``seed_from`` and ``seed_events`` are
+                given; ``worker_id`` is given but not registered; no
+                workers are registered; or ``seed_from`` is not a
+                registered thread.
+            SerializationError: ``target`` cannot be cloudpickled and
+                the chosen worker is remote.
+        """
+        ...
+
+    # ── Cross-thread operations (routed to hosting worker's adapter) ──
+
+    def submit(
+        self,
+        thread_id: ThreadId,
+        *args: Any,  # pyright: ignore[reportExplicitAny]
+        **kwargs: Any,  # pyright: ignore[reportExplicitAny]
+    ) -> Awaitable[Any]:  # pyright: ignore[reportExplicitAny]
+        """Enqueue a ``PromptRequest`` on ``thread_id``'s work queue.
+
+        Args:
+            thread_id: Id of the thread to run.
+            args: Positional arguments forwarded to ``Thread.execute``.
+            kwargs: Keyword arguments forwarded to ``Thread.execute``.
+
+        Returns:
+            An awaitable (typically an ``asyncio.Future``) that resolves
+            with the cycle's typed result. The coordinator routes the
+            request to the hosting worker's adapter.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+
+        Concurrency:
+            In-process: synchronous enqueue; future resolves later.
+            Remote: the submit frame is dispatched over the wire; the
+            returned awaitable resolves when the server relays the
+            result back.
+
+        Liveness (I12):
+            The returned awaitable MUST eventually resolve — either
+            with the cycle result, with the cycle's raised exception,
+            with ``CancelledError`` on cancel / teardown, or with a
+            transport / dispatcher error if the backing worker or
+            connection dies. Implementations may NOT orphan the
+            awaitable on any internal failure mode.
+        """
+        ...
+
+    async def notify(self, thread_id: ThreadId, text: str) -> None:
+        """Deliver a side-channel message to ``thread_id``.
+
+        Routes to the hosting worker's ``notify`` method, which
+        calls the live thread's ``Thread.notify``. No cycle is
+        started by this call.
+
+        Args:
+            thread_id: Thread receiving the message.
+            text: Message body delivered to the live thread.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def pause(self, thread_id: ThreadId) -> None:
+        """Set the pause signal on ``thread_id``.
+
+        Args:
+            thread_id: Thread to pause.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def resume(self, thread_id: ThreadId) -> None:
+        """Clear the pause signal on ``thread_id``.
+
+        Args:
+            thread_id: Thread to resume.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def cancel(self, thread_id: ThreadId) -> None:
+        """Cooperatively cancel the in-flight cycle on ``thread_id``.
+
+        Args:
+            thread_id: Thread to cancel.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def terminate(self, thread_id: ThreadId) -> None:
+        """Schedule graceful termination of ``thread_id``.
+
+        Args:
+            thread_id: Thread to terminate.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def terminate_now(self, thread_id: ThreadId) -> None:
+        """Tear ``thread_id`` down immediately.
+
+        Args:
+            thread_id: Thread to tear down.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+        """
+        ...
+
+    async def fork(self, thread_id: ThreadId) -> ThreadHandle[..., Any]:
+        """Fork ``thread_id`` into a new thread seeded with its history.
+
+        Thin sugar built on :meth:`spawn`:
+
+        1. Ask the hosting worker for a resumption spawnable via
+           ``WorkerAdapter.get_fork_spawnable`` (which delegates to
+           ``Thread.fork()``).
+        2. Call ``self.spawn(new_spawnable, seed_from=thread_id,
+           parent_id=thread_id)``.
+
+        Callers who need finer control (different seeding source,
+        different parent id, placing the child on a specific worker)
+        should use :meth:`spawn` directly.
+
+        Args:
+            thread_id: Thread to fork.
+
+        Returns:
+            A new handle (type-erased) backed by this coordinator.
+
+        Raises:
+            ThreadNotFoundError: ``thread_id`` is not registered.
+            NotImplementedError: The source thread's ``fork`` raises.
+        """
+        ...
+
+    # ── Approvals ──
+
+    async def resolve_approval(
+        self, thread_id: ThreadId, approval_id: str, decision: str,
+    ) -> None:
+        """Resolve a pending tool-approval request.
+
+        Appends an ``ApprovalDecidedEvent`` that the worker's waiting
+        ``on_interrupt`` handler observes via its event subscription.
+
+        Args:
+            thread_id: Thread whose approval is being resolved.
+            approval_id: Id of the ``APPROVAL_REQUEST`` this resolves.
+            decision: Policy decision to return to the executor.
+
+        Emits:
+            APPROVAL_DECIDED.
+        """
+        ...
+
+    # ── Events: the single emit/store/broadcast path ──
+
+    def append_event(self, event: Event) -> None:
+        """Persist ``event`` and broadcast it to subscribers.
+
+        Synchronous by design so it can be called from sync callbacks (Strands hooks,
+        streaming callback). Implementations must not block on network I/O; remote
+        variants schedule the post and return immediately, preserving per-producer
+        order via an ordering queue.
+
+        Args:
+            event: The event to append; ``event.thread_id`` must be set.
+
+        Ensures:
+            - ``event`` is durably stored before any subscriber is notified.
+            - Every matching subscriber registered via :meth:`on` observes ``event``.
+            - ``TOKEN_USAGE`` events drive this coordinator's own pause-signal state.
+            - For any single producer, events are persisted in the
+              order ``append_event`` was called (I2, I3).
+            - Side-effect isolation (I11): once the event is durably
+              stored, any failure in a status-cache update, subscriber
+              callback, or rate-limit hook is logged and swallowed.
+              ``append_event`` itself raises ONLY for the misuses
+              listed under ``Raises`` — never for downstream side-effect
+              failures. This is a hard requirement: the common caller
+              is a worker dispatcher task, and propagating would kill
+              the thread and hang pending ``handle.run`` futures.
+            - One failing subscriber MUST NOT prevent subsequent
+              subscribers from receiving ``event``.
+
+        Raises:
+            ValueError: if ``event.thread_id`` is ``None``.
+        """
+        ...
+
+    async def get_events(
+        self,
+        thread_id: ThreadId,
+        since_id: EventId | None = None,
+        kinds: list[EventKind] | None = None,
+        limit: int | None = None,
+    ) -> list[Event]:
+        """Replay stored events for ``thread_id`` in chronological order.
+
+        Args:
+            thread_id: Thread whose events are being read.
+            since_id: Return only events appended strictly after this id.
+            kinds: Restrict to these event kinds; all kinds if ``None``.
+            limit: Return at most this many events; unbounded if ``None``.
+
+        Returns:
+            Events for ``thread_id`` matching the filters, oldest first (I8).
+        """
+        ...
+
+    async def new_message_id(self) -> MessageId:
+        """Mint a fresh message id."""
+        ...
+
+    async def copy_events(
+        self,
+        source_id: ThreadId,
+        target_id: ThreadId,
+        until_event_id: EventId | None = None,
+    ) -> None:
+        """Copy every event from ``source_id`` onto ``target_id`` in order.
+
+        Used by the coordinator to seed a forked thread's event log
+        without streaming events back to the caller.
+
+        Args:
+            source_id: Thread whose events are read.
+            target_id: Thread whose log receives rewritten copies.
+            until_event_id: Copy events up to and including this id;
+                copy the entire current history when ``None``.
+
+        Ensures:
+            - Each source event is re-appended onto ``target_id`` with a
+              fresh ``event.id`` and ``thread_id=target_id``; relative
+              order is preserved.
+            - No events already on ``target_id`` are mutated or removed.
+            - Subscribers registered via :meth:`on` are NOT notified for
+              the copied events.
+            - For remote implementations, outstanding writes on the
+              source are flushed before reading (I8).
+
+        Raises:
+            ThreadNotFoundError: ``source_id`` or ``target_id`` is not registered.
+            ValueError: ``until_event_id`` does not correspond to any
+                event on ``source_id``.
+        """
+        ...
+
+    # ── Event subscriptions (live tail) ──
+
+    def on(
+        self,
+        callback: OnEventCallback,
+        *,
+        thread_id: ThreadId | None = None,
+        kinds: list[EventKind] | None = None,
+    ) -> Subscription:
+        """Register a live subscriber for future events.
+
+        Args:
+            callback: Sink invoked for each matching event appended after this call.
+            thread_id: If set, restrict deliveries to this thread.
+            kinds: If set, restrict deliveries to these event kinds.
+
+        Returns:
+            A :class:`Subscription` whose ``unsubscribe`` tears down this registration.
+
+        Ensures:
+            - ``callback`` is invoked for every event appended after registration whose
+              filters match (AND), until ``unsubscribe`` is called.
+            - Calling ``unsubscribe`` is idempotent.
+        """
+        ...
+
+    # ── Rate limiting ──
+
+    async def is_paused(self, thread_id: ThreadId) -> bool:
+        """Return whether the rate-limit / manual pause signal is set for ``thread_id``.
+
+        Args:
+            thread_id: Thread to query.
+
+        Returns:
+            True iff the thread is paused at this instant (I3, I8).
+            Callers should await :meth:`wait_until_unpaused` to block.
+        """
+        ...
+
+    def wait_until_unpaused(self, thread_id: ThreadId) -> Awaitable[None]:
+        """Await until the pause signal for ``thread_id`` is clear.
+
+        Args:
+            thread_id: Thread whose pause signal to watch.
+
+        Returns:
+            An awaitable that resolves the next time the thread is unpaused (immediately
+            if already unpaused).
+
+        Ensures:
+            Every :meth:`append_event` of ``TOKEN_USAGE`` that transitions this thread
+            out of paused state wakes outstanding awaiters (I3).
+        """
+        ...
+
+
+# ── Permission Store — tool approval policies ──
+
+@runtime_checkable
+class PermissionStore(Protocol):
+    """Store and resolve tool permission policies used by ``on_interrupt``."""
+
+    async def resolve_policy(self, thread_id: ThreadId, tool_name: str) -> Policy:
+        """Resolve the effective policy for a tool on a thread."""
+        ...
+
+    async def set_global_policy(self, tool_name: str, policy: Policy) -> None:
+        """Set the global default policy for ``tool_name``."""
+        ...
+
+    async def grant_session(self, thread_id: ThreadId, tool_name: str) -> None:
+        """Grant ``tool_name`` on ``thread_id`` for the lifetime of the session."""
+        ...
+
+    async def revoke_session(self, thread_id: ThreadId, tool_name: str) -> None:
+        """Revoke a session-scoped grant previously given by :meth:`grant_session`."""
+        ...

--- a/spec/ai_functions/runtime/__init__.pyi
+++ b/spec/ai_functions/runtime/__init__.pyi
@@ -1,0 +1,26 @@
+"""Runtime package — in-process thread execution and coordination."""
+
+from .coordinator import InMemoryCoordinator
+from .errors import (
+    ConnectionLostError,
+    DistributedError,
+    EventEmissionError,
+    SerializationError,
+    ThreadIdMismatchError,
+    ThreadNotFoundError,
+    WorkerLostError,
+)
+from .worker import LocalWorker, WorkerAdapter
+
+__all__ = [
+    "ConnectionLostError",
+    "DistributedError",
+    "EventEmissionError",
+    "InMemoryCoordinator",
+    "LocalWorker",
+    "SerializationError",
+    "ThreadIdMismatchError",
+    "ThreadNotFoundError",
+    "WorkerAdapter",
+    "WorkerLostError",
+]

--- a/spec/ai_functions/runtime/coordinator.pyi
+++ b/spec/ai_functions/runtime/coordinator.pyi
@@ -1,0 +1,22 @@
+"""InMemoryCoordinator — default single-process ``Coordinator`` implementation.
+
+Invariants:
+    I2, I3.
+"""
+
+from __future__ import annotations
+
+from ..protocols import Coordinator
+
+
+class InMemoryCoordinator(Coordinator):
+    """Single-process ``Coordinator``; events in per-thread lists, callbacks in dicts.
+
+    Implements:
+        Coordinator.
+
+    Invariants:
+        - I2 — sole sink for every event this coordinator serves.
+        - I3 — per-thread pause signals are driven by ``TOKEN_USAGE``
+          events appended here.
+    """

--- a/spec/ai_functions/runtime/errors.pyi
+++ b/spec/ai_functions/runtime/errors.pyi
@@ -1,0 +1,128 @@
+"""Errors specific to runtime execution: dispatcher and distributed transport."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ..types import EventKind, ThreadId, WorkerId
+
+
+class ThreadIdMismatchError(ValueError):
+    """An event's ``thread_id`` disagrees with the routing context.
+
+    ``worker._route_event`` stamps each event with the thread id of
+    the cycle it's being emitted from. If the caller also set
+    ``event.thread_id`` and the two disagree, the call is almost
+    certainly a bug — refusing it surfaces the mismatch at the offending
+    frame.
+
+    Args:
+        event_thread_id: ``event.thread_id`` as the caller set it.
+        routing_thread_id: ``thread_id`` ``_route_event`` was called with.
+
+    Invariants:
+        Events stored via a ``Coordinator`` always carry a ``thread_id``
+        that matches the thread whose log they live in.
+    """
+
+    event_thread_id: ThreadId
+    routing_thread_id: ThreadId
+
+    def __init__(self, event_thread_id: ThreadId, routing_thread_id: ThreadId) -> None: ...
+
+
+class EventEmissionError(RuntimeError):
+    """An event of the wrong kind was routed through ``worker._route_event``.
+
+    The runtime routing gates all ``append_event`` calls through a single routing
+    function that knows who the emitter is:
+
+    - ``source="thread"`` — calls from inside a cycle, delivered via
+      ``ThreadContext.on_event``. These may NOT emit lifecycle events
+      (``STARTED``, ``COMPLETED``, ``FAILED``, ``CANCELLED``, ``RESULT``);
+      lifecycle emission is the dispatcher's job (I5).
+    - ``source="runtime"`` — calls from the runtime itself (dispatcher,
+      message router, approval handling, session management). These may
+      NOT emit ``MESSAGE_USER`` events; user-message emission is the
+      bridge hook's job (I7).
+
+    Args:
+        kind: The ``EventKind`` the caller tried to emit.
+        thread_id: Id of the thread whose log the event targeted.
+        source: Where the call came from (``"runtime"`` or ``"thread"``).
+
+    Invariants:
+        I5, I7.
+    """
+
+    kind: EventKind
+    thread_id: ThreadId
+    source: Literal["runtime", "thread"]
+
+    def __init__(
+        self,
+        kind: EventKind,
+        thread_id: ThreadId,
+        source: Literal["runtime", "thread"],
+    ) -> None: ...
+
+
+class ThreadNotFoundError(KeyError):
+    """The coordinator has no thread registered under the given id.
+
+    Raised by every ``Coordinator`` method that takes a ``thread_id``
+    and must route to a worker. Callers that want an Option-style
+    lookup should catch this explicitly.
+
+    Args:
+        thread_id: The id that was not found.
+    """
+
+    thread_id: ThreadId
+
+    def __init__(self, thread_id: ThreadId) -> None: ...
+
+
+class DistributedError(Exception):
+    """Base error for distributed execution failures."""
+
+
+class WorkerLostError(DistributedError):
+    """Worker process crashed or disconnected.
+
+    Args:
+        worker_id: Identifier of the worker that was lost.
+        thread_ids: Ids of threads previously hosted on this worker.
+    """
+
+    worker_id: WorkerId
+    thread_ids: list[ThreadId]
+
+    def __init__(self, worker_id: WorkerId, thread_ids: list[ThreadId]) -> None: ...
+
+
+class SerializationError(DistributedError):
+    """Spawnable could not be cloudpickled for remote execution.
+
+    Args:
+        function_name: Name of the spawnable that failed to serialise.
+        reason: Cloudpickle error text.
+    """
+
+    function_name: str
+
+    def __init__(self, function_name: str, reason: str) -> None: ...
+
+
+class ConnectionLostError(DistributedError):
+    """WebSocket connection to the server was lost and reconnection failed.
+
+    Args:
+        url: WebSocket URL that could not be reached.
+        retries: Number of failed reconnection attempts.
+    """
+
+    url: str
+    retries: int
+
+    def __init__(self, url: str, retries: int) -> None: ...

--- a/spec/ai_functions/runtime/worker.pyi
+++ b/spec/ai_functions/runtime/worker.pyi
@@ -1,0 +1,366 @@
+"""Worker: process-local execution engine.
+
+A worker owns one asyncio dispatcher task per thread it hosts, plus the
+queues, signals, and live ``Thread`` instances needed to drive them. It
+registers itself with a :class:`Coordinator` and serves operations that
+the coordinator routes to it via the :class:`WorkerAdapter` protocol.
+
+A concrete :class:`LocalWorker` is provided. Users who want a different
+execution strategy (multi-process, thread-pool-backed, etc.) can write
+their own concrete class that implements ``WorkerAdapter``; there is no
+``Worker`` protocol beyond the adapter.
+
+Invariants:
+    - I1 — the worker is the sole host for every thread it registers.
+    - I4 — the dispatcher task for a thread is created only after all
+      per-thread state (and any seeded history) is fully populated.
+    - I5 — the dispatcher is the sole emitter of lifecycle events
+      (``STARTED``, ``COMPLETED``, ``CANCELLED``, ``FAILED``, ``RESULT``).
+    - I12 — if a dispatcher task dies with an uncaught exception,
+      every pending ``PromptRequest`` future on that thread MUST be
+      failed with that exception. No caller of ``handle.run(...)`` is
+      allowed to hang because the dispatcher crashed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Protocol, Self, runtime_checkable
+
+from ..handle import ThreadHandle
+from ..protocols import Coordinator, Spawnable
+from ..types import ThreadId, WorkerId
+
+
+# ── Work items ──
+
+
+@dataclass
+class PromptRequest[T]:
+    """A ``handle.run(*args, **kwargs)`` request carried through the work queue."""
+
+    args: tuple[object, ...]
+    kwargs: dict[str, object]
+    future: asyncio.Future[T]
+
+
+class TerminateAfterIdle:
+    """Graceful termination marker; dispatcher runs teardown and exits on dequeue."""
+
+
+WorkItem = PromptRequest[Any] | TerminateAfterIdle  # pyright: ignore[reportExplicitAny]
+
+
+# ── WorkerAdapter protocol ──
+
+
+@runtime_checkable
+class WorkerAdapter(Protocol):
+    """Contract the coordinator uses to reach a worker.
+
+    Public extension point: any class satisfying this protocol can act
+    as a worker behind a :class:`Coordinator`. The library ships
+    :class:`LocalWorker` as the default in-process implementation and
+    builds an internal shim for remote workers served through the
+    network endpoint. Most users never implement this protocol
+    themselves — :class:`LocalWorker` is expected to cover in-process
+    execution, and the network layer covers cross-process execution.
+
+    Every method takes a ``thread_id`` the adapter is expected to host
+    (the coordinator guarantees this via its registration table; the
+    adapter may raise ``ThreadNotFoundError`` if asked to operate on a
+    thread it doesn't host).
+    """
+
+    @property
+    def worker_id(self) -> WorkerId:
+        """Stable id assigned to this worker at registration time."""
+        ...
+
+    async def spawn[**P, T](
+        self,
+        target: Spawnable[P, T],
+        *,
+        thread_id: ThreadId,
+        thread_name: str | None,
+        parent_id: ThreadId | None,
+        metadata: dict[str, object],
+    ) -> None:
+        """Allocate per-thread state on this worker for ``thread_id``.
+
+        Invoked by ``Coordinator.spawn`` after the coordinator has
+        allocated the thread id and registered the ``ThreadInfo``.
+        The adapter builds the live ``Thread`` from ``target``
+        (in-process ``target.to_thread()`` for ``LocalWorker``;
+        cloudpickle-then-``to_thread`` for remote workers), allocates
+        its work queue and pause/cancel signals, and starts the
+        dispatcher task.
+
+        The coordinator, not the adapter, is responsible for calling
+        ``register_thread`` and ``copy_events``; the adapter is only
+        responsible for the worker-local per-thread state and the
+        dispatcher lifecycle (I4).
+
+        Args:
+            target: Spawnable whose ``to_thread`` produces the live instance.
+            thread_id: Id the coordinator has already allocated.
+            thread_name: Human label for telemetry.
+            parent_id: Id of the parent thread for hierarchical rollup.
+            metadata: Application metadata attached to the thread.
+        """
+        ...
+
+    def submit(
+        self,
+        thread_id: ThreadId,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ) -> asyncio.Future[Any]:  # pyright: ignore[reportExplicitAny]
+        """Enqueue a ``PromptRequest`` on ``thread_id``'s work queue.
+
+        Args:
+            thread_id: Thread whose queue receives the request.
+            args: Positional arguments forwarded to ``Thread.execute``.
+            kwargs: Keyword arguments forwarded to ``Thread.execute``.
+
+        Returns:
+            A future the dispatcher resolves once the cycle completes.
+
+        Concurrency:
+            Synchronous enqueue; the cycle runs later on the dispatcher.
+
+        Liveness (I12):
+            The returned future MUST eventually resolve. If the
+            dispatcher task dies with an uncaught exception, the
+            adapter is responsible for failing this future (and every
+            other pending future on ``thread_id``) with that exception
+            rather than leaving callers awaiting forever.
+            :class:`LocalWorker` attaches a done-callback on the
+            dispatcher task to enforce this; remote adapters must
+            surface the equivalent signal.
+        """
+        ...
+
+    async def notify(self, thread_id: ThreadId, text: str) -> None:
+        """Deliver a side-channel message to ``thread_id``'s live instance.
+
+        Forwards to ``Thread.notify``. No cycle is started by
+        this call.
+
+        Args:
+            thread_id: Thread receiving the message.
+            text: Message body delivered to the live thread.
+        """
+        ...
+
+    async def cancel(self, thread_id: ThreadId) -> None:
+        """Cooperatively cancel the in-flight cycle on ``thread_id``.
+
+        Args:
+            thread_id: Thread whose in-flight cycle should be cancelled.
+        """
+        ...
+
+    async def pause(self, thread_id: ThreadId) -> None:
+        """Set ``thread_id``'s pause signal.
+
+        Args:
+            thread_id: Thread to pause.
+        """
+        ...
+
+    async def resume(self, thread_id: ThreadId) -> None:
+        """Clear ``thread_id``'s pause signal.
+
+        Args:
+            thread_id: Thread to resume.
+        """
+        ...
+
+    async def terminate(self, thread_id: ThreadId) -> None:
+        """Schedule graceful termination behind currently-queued work.
+
+        Args:
+            thread_id: Thread to terminate.
+        """
+        ...
+
+    async def terminate_now(self, thread_id: ThreadId) -> None:
+        """Tear ``thread_id`` down immediately; cancel in-flight, drop queued work.
+
+        Args:
+            thread_id: Thread to tear down.
+        """
+        ...
+
+    async def get_fork_spawnable(self, thread_id: ThreadId) -> Spawnable[..., Any]:  # pyright: ignore[reportExplicitAny]
+        """Return a resumption spawnable for ``thread_id``.
+
+        Delegates to the live ``Thread.fork()``. The returned spawnable
+        is safe to pass to ``Coordinator.spawn`` with ``seed_from`` to
+        materialize the forked thread.
+
+        Args:
+            thread_id: Source thread whose fork spawnable is requested.
+
+        Returns:
+            A spawnable that, when instantiated, resumes the source
+            thread's non-event state (if any).
+
+        Raises:
+            NotImplementedError: The thread does not support forking.
+        """
+        ...
+
+    def resolve_approval(
+        self,
+        thread_id: ThreadId,
+        approval_id: str,
+        decision: str,
+    ) -> bool:
+        """Resolve a pending tool-approval future inside this worker.
+
+        Invoked by the coordinator when a user calls
+        ``Coordinator.resolve_approval``. The adapter completes the
+        pending future held by its ``on_interrupt`` handler; the
+        coordinator then appends the ``ApprovalDecidedEvent``.
+
+        Args:
+            thread_id: Thread whose approval future is being resolved.
+            approval_id: Id of the ``APPROVAL_REQUEST`` this resolves.
+            decision: Policy decision to return to the executor.
+
+        Returns:
+            True iff a matching pending future was found and resolved.
+        """
+        ...
+
+
+# ── LocalWorker — default in-process implementation ──
+
+
+class LocalWorker(WorkerAdapter):
+    """In-process thread execution engine.
+
+    Owns asyncio dispatcher tasks, per-thread work queues, pause/cancel
+    signals, and the live ``Thread`` instances it hosts. Registers with
+    the coordinator on first use (or explicitly via :meth:`register`)
+    and deregisters on :meth:`close`.
+
+    User-facing surface is narrow: construct with a coordinator, use
+    :meth:`spawn_locally` for the in-process escape hatch (no
+    serialization — the spawnable is passed by reference), call
+    :meth:`close` to tear the worker down. Everything else flows through
+    the coordinator.
+
+    Args:
+        coordinator: The coordinator this worker will register with.
+        worker_id: Optional explicit id; a uuid is minted otherwise.
+
+    Ensures:
+        - Construction is pure: no I/O, no coroutine scheduling.
+        - ``self`` is not yet registered with ``coordinator``.
+        - No threads are hosted until :meth:`spawn_locally` or
+          :meth:`spawn` is called.
+    """
+
+    def __init__(
+        self,
+        coordinator: Coordinator,
+        *,
+        worker_id: WorkerId | None = None,
+    ) -> None: ...
+
+    @property
+    def coordinator(self) -> Coordinator:
+        """The coordinator this worker is registered with."""
+        ...
+
+    async def register(self) -> Self:
+        """Register this worker with the coordinator.
+
+        Idempotent. Called automatically on the first
+        :meth:`spawn_locally` / :meth:`spawn`; callers may invoke it
+        eagerly to surface registration failures before a spawn is
+        attempted.
+
+        Returns:
+            ``self``, so construction and registration can be chained
+            (e.g. ``worker = await LocalWorker(coord).register()``).
+
+        Ensures:
+            After return, ``self.worker_id`` is in the coordinator's
+            worker pool.
+        """
+        ...
+
+    # ── User-facing spawn (no serialization) ──
+
+    async def spawn_locally[**P, T](
+        self,
+        target: Spawnable[P, T],
+        *,
+        thread_id: ThreadId | None = None,
+        thread_name: str | None = None,
+        parent_id: ThreadId | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> ThreadHandle[P, T]:
+        """Host a new thread on this worker and return a handle to it.
+
+        The escape hatch for spawnables that cannot survive
+        cloudpickling: ``target`` is passed by reference, never
+        serialized. The created thread is registered with
+        ``self.coordinator`` before the dispatcher starts (I4); the
+        returned handle is backed by that coordinator.
+
+        Named ``spawn_locally`` (rather than ``spawn``) to avoid
+        collision with the ``WorkerAdapter.spawn`` method the coordinator
+        calls when routing a generic ``Coordinator.spawn`` request.
+
+        Args:
+            target: Spawnable whose ``to_thread`` produces the live instance.
+            thread_id: Explicit id; one is minted if omitted.
+            thread_name: Human label for telemetry.
+            parent_id: Id of the parent thread for hierarchical rollup.
+            metadata: Application metadata attached to the thread.
+
+        Returns:
+            A ``ThreadHandle`` whose coordinator is ``self.coordinator``.
+
+        Ensures:
+            - ``self.coordinator`` knows about the thread before the
+              dispatcher starts (I4).
+            - The dispatcher task is running, blocked on ``q.get``.
+        """
+        ...
+
+    def has_thread(self, thread_id: ThreadId) -> bool:
+        """Return True iff this worker currently hosts ``thread_id``.
+
+        Args:
+            thread_id: Thread to probe.
+
+        Returns:
+            True if ``thread_id`` is hosted here, else False.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Gracefully terminate every thread hosted by this worker.
+
+        Each thread is ``terminate``-d (its ``TerminateAfterIdle`` flow
+        runs, which tears down any local resources via
+        ``Thread.teardown``). After every thread's dispatcher exits,
+        the worker deregisters itself from the coordinator.
+
+        Ensures:
+            - No thread hosted by this worker remains registered with
+              the coordinator.
+            - ``self`` is deregistered from the coordinator's worker
+              pool.
+
+        Concurrency:
+            Idempotent; closing an already-closed worker is a no-op.
+        """
+        ...

--- a/spec/ai_functions/testing/__init__.pyi
+++ b/spec/ai_functions/testing/__init__.pyi
@@ -1,0 +1,15 @@
+"""Test helpers — not imported by the runtime package by default."""
+
+from .harness import RuntimeHarness
+from .messages import assert_messages_equivalent, normalize_messages
+from .scripted_model import AwaitBarrier, ScriptedModel, ScriptExhausted, Turn
+
+__all__ = [
+    "AwaitBarrier",
+    "RuntimeHarness",
+    "ScriptExhausted",
+    "ScriptedModel",
+    "Turn",
+    "assert_messages_equivalent",
+    "normalize_messages",
+]

--- a/spec/ai_functions/testing/_barriers.pyi
+++ b/spec/ai_functions/testing/_barriers.pyi
@@ -1,0 +1,58 @@
+"""Shared barrier registry used by ``ScriptedModel`` and ``RuntimeHarness``.
+
+Private to ``ai_functions.testing``. The contextvar is set by
+``RuntimeHarness.__aenter__`` so scripted models spawned inside the
+``async with`` block resolve barrier names against the active harness.
+"""
+
+import asyncio
+from contextvars import ContextVar
+
+
+class BarrierRegistry:
+    """Named ``asyncio.Event`` store shared by a harness and its scripted models.
+
+    Creates an empty registry.
+    """
+
+    def __init__(self) -> None: ...
+
+    def get(self, name: str) -> asyncio.Event:
+        """Return the (lazily created) event for ``name``.
+
+        Args:
+            name: Barrier name.
+
+        Returns:
+            The ``asyncio.Event`` for ``name``; created on first access.
+        """
+        ...
+
+    def release(self, name: str) -> None:
+        """Set the event for ``name``, unblocking all current and future awaits.
+
+        Args:
+            name: Barrier name.
+        """
+        ...
+
+    def release_all(self) -> None:
+        """Set every known event so pending awaiters unwind on harness teardown."""
+        ...
+
+
+current_registry: ContextVar[BarrierRegistry | None]
+"""Contextvar carrying the active harness's registry; ``None`` outside a
+harness."""
+
+
+async def await_barrier(name: str) -> None:
+    """Block until the named barrier is released by the active harness.
+
+    Args:
+        name: Barrier name.
+
+    Raises:
+        RuntimeError: No ``RuntimeHarness`` is active in this context.
+    """
+    ...

--- a/spec/ai_functions/testing/harness.pyi
+++ b/spec/ai_functions/testing/harness.pyi
@@ -1,0 +1,206 @@
+"""Test harness bundling a ``LocalWorker``, coordinator, and barrier registry.
+
+``RuntimeHarness`` is an async context manager that wires up a worker,
+gives tests ergonomic access to event logs, and provides synchronization
+primitives for concurrency tests:
+
+- ``wait_for`` blocks until a matching event is appended (scanning the
+  existing log first, then subscribing via ``Coordinator.on``).
+- ``release`` unblocks a barrier that a ``ScriptedModel`` is suspended on.
+
+Barriers are wired via a ``ContextVar`` set during ``__aenter__``: any
+``ScriptedModel`` used inside the ``async with`` block resolves its
+barrier names against the harness automatically. Parallel harnesses have
+independent registries because each ``async with`` runs in its own task
+context.
+"""
+
+from types import TracebackType
+from typing import Self, final
+
+from strands.types.content import Messages
+
+from ..runtime.worker import LocalWorker
+from ..protocols import Coordinator, Spawnable
+from ..types import Event, EventKind, ThreadId
+from ..handle import ThreadHandle
+
+
+@final
+class RuntimeHarness:
+    """Test wiring for a ``LocalWorker`` with observability and barrier release.
+
+    Usage::
+
+        async with RuntimeHarness() as h:
+            handle = h.spawn(my_fn.replace(model=ScriptedModel([...])))
+            result = await handle.run("hi")
+            h.events(handle.thread_id)
+
+    Args:
+        coordinator: A pre-built coordinator; a fresh ``InMemoryCoordinator``
+            is constructed on ``__aenter__`` when ``None``.
+        worker: A pre-built ``LocalWorker`` bound to the coordinator; a fresh
+            one is constructed on ``__aenter__`` when ``None``.
+
+    Ensures:
+        Barrier registry is empty until ``__aenter__`` runs.
+    """
+
+    def __init__(
+        self,
+        *,
+        coordinator: Coordinator | None = None,
+        worker: LocalWorker | None = None,
+    ) -> None: ...
+
+    async def __aenter__(self) -> Self:
+        """Install the barrier contextvar and returns self.
+
+        Ensures:
+            - ``self.worker`` is a live ``LocalWorker``.
+            - Any ``ScriptedModel`` constructed and used inside the ``async with`` block
+              resolves barriers against this harness.
+        """
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Tear down the worker and release all barriers.
+
+        Args:
+            exc_type: Exception class raised inside the ``with`` block, if any.
+            exc: Exception instance raised inside the ``with`` block, if any.
+            tb: Traceback for the raised exception, if any.
+
+        Ensures:
+            - Every registered dispatcher is cancelled and awaited.
+            - Every pending barrier is released so scripted models can unwind.
+            - The contextvar token set in ``__aenter__`` is reset.
+        """
+        ...
+
+    # ── Spawning ──
+
+    async def spawn[**P, T](
+        self,
+        target: Spawnable[P, T],
+        *,
+        thread_id: ThreadId | None = None,
+        thread_name: str | None = None,
+        parent_id: ThreadId | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> ThreadHandle[P, T]:
+        """Spawn a thread on the underlying worker and remember it.
+
+        Delegates to ``self.worker.spawn_locally`` and additionally
+        hooks an ``AfterInvocationEvent`` listener that captures the
+        final ``agent.messages`` for :meth:`agent_messages`.
+
+        Args:
+            target: Spawnable whose ``to_thread`` produces the live instance.
+            thread_id: Explicit id; one is minted if omitted.
+            thread_name: Human label for telemetry.
+            parent_id: Id of the parent thread for hierarchical rollup.
+            metadata: Application metadata attached to the thread.
+
+        Returns:
+            A ``ThreadHandle`` in ``NOT_STARTED`` state.
+        """
+        ...
+
+    # ── Observation ──
+
+    async def events(
+        self,
+        thread_id: ThreadId,
+        *,
+        kinds: list[EventKind] | None = None,
+    ) -> list[Event]:
+        """Snapshot of events emitted for ``thread_id``.
+
+        Args:
+            thread_id: Thread whose events are requested.
+            kinds: Restrict to these event kinds; all kinds if ``None``.
+
+        Returns:
+            Events in append order.
+        """
+        ...
+
+    def agent_messages(self, thread_id: ThreadId) -> Messages:
+        """Return the Strands ``Messages`` captured after the most recent cycle.
+
+        Args:
+            thread_id: Thread whose captured messages are requested.
+
+        Returns:
+            The ``agent.messages`` list copied at cycle completion; an empty list if no
+            cycle has completed yet on this thread.
+
+        Requires:
+            ``thread_id`` was spawned through ``self.spawn`` (the harness
+            attaches the capture hook on spawn).
+        """
+        ...
+
+    # ── Synchronization ──
+
+    async def wait_for(
+        self,
+        thread_id: ThreadId,
+        kind: EventKind,
+        *,
+        timeout: float = 2.0,
+    ) -> Event:
+        """Wait until an event of ``kind`` is appended for ``thread_id``.
+
+        Scans the existing event log first, so a ``wait_for`` issued after the event has
+        already arrived resolves immediately.
+
+        Args:
+            thread_id: Thread whose log is being watched.
+            kind: Event kind to match.
+            timeout: Seconds before raising ``asyncio.TimeoutError``.
+
+        Returns:
+            The matching event.
+
+        Raises:
+            asyncio.TimeoutError: No matching event arrived within ``timeout``.
+        """
+        ...
+
+    def release(self, barrier: str) -> None:
+        """Unblock a ``ScriptedModel`` barrier by name.
+
+        Args:
+            barrier: Name of the barrier (from ``Turn.await_before``,
+                ``Turn.await_after``, or an ``AwaitBarrier`` sentinel).
+
+        Ensures:
+            Any current or future await on this barrier resolves.
+
+        Concurrency:
+            Idempotent — releasing an already-released barrier is a no-op.
+        """
+        ...
+
+    # ── Properties ──
+
+    @property
+    def worker(self) -> LocalWorker:
+        """The underlying worker.
+
+        Raises if accessed before ``__aenter__``.
+        """
+        ...
+
+    @property
+    def coordinator(self) -> Coordinator:
+        """The underlying coordinator backing the worker."""
+        ...

--- a/spec/ai_functions/testing/messages.pyi
+++ b/spec/ai_functions/testing/messages.pyi
@@ -1,0 +1,49 @@
+"""Message-history comparison utilities for harness-based tests.
+
+Used to compare ``agent.messages`` against ``reconstruct_messages(events)``. The
+normalizer strips only the ``metadata`` key that Strands attaches to assistant
+messages as post-hoc telemetry — no other shape changes — so tests that fail indicate
+genuine divergence between the live agent history and the event-log reconstruction."""
+
+from strands.types.content import Messages
+
+
+def normalize_messages(messages: Messages) -> Messages:
+    """Return a canonical form suitable for equality comparison.
+
+    The only normalization applied is stripping the ``metadata`` key that Strands
+    attaches to assistant messages in ``event_loop.event_loop``
+    (``message["metadata"] = {"usage": ..., "metrics": ...}``). That field is post-hoc
+    telemetry: populated after ``AfterModelCallEvent``, not part of the conversation
+    the model observes on replay, and discarded by Strands' own
+    ``_normalize_messages`` before the next model call.
+
+    No other normalization is applied. In particular, consecutive same-role messages
+    are NOT merged — Strands does not merge them either. The round-trip property
+    ``agent.messages == reconstruct_messages(events)`` is exactly that: equality
+    after stripping ``metadata``.
+
+    Args:
+        messages: A Strands-format message list.
+
+    Returns:
+        A deep copy with ``metadata`` keys removed from every message.
+
+    Ensures:
+        The returned list is a deep copy; callers may mutate freely.
+    """
+    ...
+
+
+def assert_messages_equivalent(actual: Messages, expected: Messages) -> None:
+    """Assert two message histories are equal after ``normalize_messages``.
+
+    Args:
+        actual: The observed message history.
+        expected: The reference message history.
+
+    Raises:
+        AssertionError: The normalized histories differ; the message
+            includes a unified diff of the JSON-serialized forms.
+    """
+    ...

--- a/spec/ai_functions/testing/scripted_model.pyi
+++ b/spec/ai_functions/testing/scripted_model.pyi
@@ -1,0 +1,182 @@
+"""Scripted ``strands.Model`` implementation for deterministic agent tests.
+
+``ScriptedModel`` plays back a fixed sequence of model turns. Each ``Turn`` describes
+one model call: streamed text chunks followed by optional tool calls. Tests drive
+agent behaviour by writing a small script; streaming is real (chunks are yielded
+between ``await`` points) so concurrency tests can observe partial state.
+
+Barriers (``await_before``/``await_after`` on a ``Turn``, and ``AwaitBarrier``
+sentinels inside ``text_chunks``) suspend the stream until ``RuntimeHarness.release``
+is called. The connection between model and harness is carried by a ``ContextVar``
+set in ``RuntimeHarness.__aenter__`` — tests don't attach models explicitly."""
+
+from collections.abc import AsyncGenerator, AsyncIterable
+from dataclasses import dataclass
+from typing import Any, final
+
+from pydantic import BaseModel
+from strands.models.model import Model
+from strands.types.content import Messages, SystemContentBlock
+from strands.types.streaming import StreamEvent
+from strands.types.tools import ToolChoice, ToolSpec
+
+
+@final
+@dataclass(frozen=True)
+class AwaitBarrier:
+    """Sentinel placed inside ``Turn.text_chunks`` to suspend streaming mid-turn.
+
+    When the scripted model reaches this sentinel it yields every chunk emitted so
+    far, then awaits the harness barrier named ``name``. The next chunk after the
+    sentinel is only streamed once ``RuntimeHarness.release(name)`` is called.
+    """
+
+    name: str
+    """Barrier name; matched against ``RuntimeHarness.release`` calls."""
+
+
+@final
+@dataclass(frozen=True)
+class Turn:
+    """One scripted model call.
+
+    A ``Turn`` describes what the model will emit on one invocation of
+    ``Model.stream``: zero-or-more text chunks, then zero-or-more tool calls. Stop
+    reason is ``"tool_use"`` if ``tool_calls`` is non-empty, ``"end_turn"`` otherwise.
+
+    Exactly one of ``text`` or ``text_chunks`` may be provided (or neither,
+    if the turn is a pure tool call). When ``text`` is given, ``ScriptedModel``
+    splits it into word-sized chunks automatically; when ``text_chunks`` is given,
+    each entry becomes one streamed chunk verbatim. A mid-stream ``AwaitBarrier``
+    must appear inside ``text_chunks``.
+    """
+
+    text: str | None = None
+    """Plain text to stream; automatically split on whitespace into word
+    chunks."""
+
+    text_chunks: tuple[str | AwaitBarrier, ...] | None = None
+    """Explicit chunk list; each entry is one ``contentBlockDelta`` (or a
+    barrier)."""
+
+    tool_calls: tuple[tuple[str, dict[str, object]], ...] = ()
+    """``(tool_name, tool_input)`` pairs emitted as tool-use blocks after
+    text."""
+
+    await_before: str | None = None
+    """Barrier name blocked on at the start of this turn, before any chunk
+    is yielded."""
+
+    await_after: str | None = None
+    """Barrier name blocked on at the end of this turn, after
+    ``messageStop``."""
+
+    input_tokens: int = 0
+    """Reported in the terminal ``metadata.usage.inputTokens`` for this turn."""
+
+    output_tokens: int = 0
+    """Reported in the terminal ``metadata.usage.outputTokens`` for this turn."""
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous or empty configurations.
+
+        Raises:
+            ValueError: Both ``text`` and ``text_chunks`` are set, or the turn has no
+                text and no tool calls.
+        """
+        ...
+
+
+class ScriptExhausted(RuntimeError):
+    """Raised when the agent requests more model calls than the script provides."""
+
+
+@final
+class ScriptedModel(Model):
+    """Deterministic ``strands.Model`` that plays back a ``list[Turn]``.
+
+    The script is fixed at construction; per-call state (cursor) is mutable.
+
+    Args:
+        turns: One ``Turn`` per expected model call, in order.
+
+    Ensures:
+        ``self.remaining_turns == len(turns)``.
+    """
+
+    def __init__(self, turns: list[Turn]) -> None: ...
+
+    @property
+    def remaining_turns(self) -> int:
+        """Turns not yet consumed by a ``stream`` call."""
+        ...
+
+    def update_config(self, **model_config: Any) -> None:  # pyright: ignore[reportExplicitAny, reportAny]
+        """No-op for compatibility with ``strands.Model``.
+
+        Args:
+            model_config: Ignored; ``ScriptedModel`` has no mutable config.
+        """
+        ...
+
+    def get_config(self) -> dict[str, object]:
+        """Return a snapshot of the model's state.
+
+        Returns:
+            A dict with ``{"remaining_turns": int}``.
+        """
+        ...
+
+    def stream(
+        self,
+        messages: Messages,
+        tool_specs: list[ToolSpec] | None = None,
+        system_prompt: str | None = None,
+        *,
+        tool_choice: ToolChoice | None = None,
+        system_prompt_content: list[SystemContentBlock] | None = None,
+        invocation_state: dict[str, Any] | None = None,  # pyright: ignore[reportExplicitAny]
+        **kwargs: Any,  # pyright: ignore[reportExplicitAny]
+    ) -> AsyncIterable[StreamEvent]:
+        """Yield the Bedrock-shaped stream for the next scripted turn.
+
+        Args:
+            messages: Conversation history; not consulted by ``ScriptedModel``.
+            tool_specs: Available tool specs; ignored (scripted turns name their target
+                tool directly).
+            system_prompt: Ignored.
+            tool_choice: Ignored.
+            system_prompt_content: Ignored.
+            invocation_state: Ignored.
+            kwargs: Ignored.
+
+        Returns:
+            An async iterable that yields one ``messageStart``, the turn's text and
+            tool-use content blocks (with barriers honored), then ``messageStop`` and
+            ``metadata``.
+
+        Raises:
+            ScriptExhausted: The script has no more turns.
+        """
+        ...
+
+    def structured_output(
+        self,
+        output_model: type[BaseModel],
+        prompt: Messages,
+        system_prompt: str | None = None,
+        **kwargs: Any,  # pyright: ignore[reportExplicitAny]
+    ) -> AsyncGenerator[dict[str, BaseModel | Any]]:  # pyright: ignore[reportExplicitAny]
+        """Unsupported path — ``ScriptedModel`` drives agents via ``stream`` only.
+
+        Args:
+            output_model: Ignored.
+            prompt: Ignored.
+            system_prompt: Ignored.
+            kwargs: Ignored.
+
+        Raises:
+            NotImplementedError: Always; tests should rely on tool-call turns targeting
+                the structured-output wrapper instead.
+        """
+        ...

--- a/spec/ai_functions/types/__init__.pyi
+++ b/spec/ai_functions/types/__init__.pyi
@@ -1,0 +1,78 @@
+"""Framework-wide data types — value classes and enums used across subsystems.
+
+These types are not tied to any single ``Thread`` implementation. Types
+that belong to a specific thread family (e.g. ``ThreadConfig``,
+``PostCondition``, AIThread-specific errors) live next to that
+implementation — see ``ai_functions.ai_thread``.
+"""
+
+from __future__ import annotations
+
+from .context import ThreadContext
+from .events import (
+    ApprovalDecidedEvent,
+    ApprovalRequestEvent,
+    BaseEvent,
+    CancelledEvent,
+    CompletedEvent,
+    ContextSummarizedEvent,
+    CustomEvent,
+    Event,
+    EventKind,
+    FailedEvent,
+    MessageAssistantCompleteEvent,
+    MessageAssistantStartEvent,
+    MessageAssistantThinkingEvent,
+    MessageAssistantTokenEvent,
+    MessageUserEvent,
+    RenderableEvent,
+    ResultEvent,
+    SessionCreatedEvent,
+    SessionResetEvent,
+    StartedEvent,
+    TokenUsage,
+    TokenUsageEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+    is_renderable_event,
+)
+from .ids import EventId, MessageId, ThreadId, WorkerId
+from .policy import Policy
+from .status import InputShape, ThreadInfo, ThreadStatus
+
+__all__ = [
+    "ApprovalDecidedEvent",
+    "ApprovalRequestEvent",
+    "BaseEvent",
+    "CancelledEvent",
+    "CompletedEvent",
+    "ContextSummarizedEvent",
+    "CustomEvent",
+    "Event",
+    "EventId",
+    "EventKind",
+    "FailedEvent",
+    "InputShape",
+    "MessageAssistantCompleteEvent",
+    "MessageAssistantStartEvent",
+    "MessageAssistantThinkingEvent",
+    "MessageAssistantTokenEvent",
+    "MessageId",
+    "MessageUserEvent",
+    "Policy",
+    "RenderableEvent",
+    "ResultEvent",
+    "SessionCreatedEvent",
+    "SessionResetEvent",
+    "StartedEvent",
+    "ThreadContext",
+    "ThreadId",
+    "ThreadInfo",
+    "ThreadStatus",
+    "TokenUsage",
+    "TokenUsageEvent",
+    "ToolCallEvent",
+    "ToolResultEvent",
+    "WorkerId",
+    "is_renderable_event",
+]

--- a/spec/ai_functions/types/context.pyi
+++ b/spec/ai_functions/types/context.pyi
@@ -1,0 +1,49 @@
+"""Per-cycle runtime context the runtime passes to ``Thread.execute``."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..protocols import Coordinator, OnEventCallback, OnInterruptCallback
+
+from .ids import ThreadId
+
+
+@dataclass
+class ThreadContext:
+    """Runtime context the worker builds fresh for every cycle.
+
+    Invariants:
+        - Every field is populated by the worker; executors may rely on
+          non-None values.
+        - A ``ThreadContext`` instance is never reused across cycles.
+    """
+
+    thread_id: ThreadId
+    """Id of the thread this cycle runs on."""
+
+    coordinator: Coordinator
+    """The coordinator this thread is registered with. Threads use it to
+    spawn children, inject messages into peers, read events, and
+    introspect the thread registry."""
+
+    on_event: OnEventCallback
+    """Sink bound to ``Coordinator.append_event`` for content, tool, and usage events."""
+
+    on_interrupt: OnInterruptCallback
+    """Handler for a batch of executor-raised interrupts; awaited inline."""
+
+    pause_signal: asyncio.Event
+    """Rate-limit / manual-pause signal the executor MUST await at every model-call boundary."""
+
+    cancel_signal: asyncio.Event
+    """Cooperative-cancel signal the executor MUST check at every model-call boundary."""
+
+    parent_id: ThreadId | None = None
+    """Id of the parent thread, if this thread was spawned with a ``parent_id``."""
+
+    metadata: dict[str, object] = field(default_factory=lambda: dict[str, object]())
+    """Application metadata (priority, etc.)."""

--- a/spec/ai_functions/types/events.pyi
+++ b/spec/ai_functions/types/events.pyi
@@ -1,0 +1,460 @@
+"""Event hierarchy emitted through ``Coordinator.append_event``.
+
+``Event`` is a discriminated-union hierarchy rooted at ``BaseEvent``. Each
+concrete subclass carries a distinct ``kind`` string and only the payload
+fields that apply to that kind.
+
+System events have ``kind`` values drawn from ``EventKind`` (a ``StrEnum``).
+User-defined events use any other string: subclass ``CustomEvent``, set
+``kind`` to a stable application-level identifier, and add whatever fields
+you need. Pydantic routes unknown ``kind`` values to ``CustomEvent`` via a
+custom discriminator function, so the full ``Event`` union round-trips
+across the wire without losing user-defined subclasses.
+
+Filtering is uniform for both system and custom events — pass any ``kind``
+string (``EventKind`` member or plain string) to ``Coordinator.on(kinds=...)``
+or ``Coordinator.get_events(kinds=...)``.
+
+Invariants:
+    I2.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from typing import Annotated, Literal, TypeGuard
+
+from pydantic import BaseModel, ConfigDict, Field
+from strands.types.content import ContentBlock
+from strands.types.tools import ToolResultContent, ToolResultStatus
+
+from .ids import EventId, MessageId, ThreadId
+
+
+class EventKind(enum.StrEnum):
+    """Discriminator values for built-in event variants.
+
+    Any string outside this set is valid as a user-defined ``kind``;
+    pydantic will route it to ``CustomEvent``.
+    """
+
+    STARTED = "started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+    MESSAGE_USER = "message_user"
+    MESSAGE_ASSISTANT_START = "message_assistant_start"
+    MESSAGE_ASSISTANT_TOKEN = "message_assistant_token"
+    MESSAGE_ASSISTANT_THINKING = "message_assistant_thinking"
+    MESSAGE_ASSISTANT_COMPLETE = "message_assistant_complete"
+
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+
+    APPROVAL_REQUEST = "approval_request"
+    APPROVAL_DECIDED = "approval_decided"
+
+    SESSION_CREATED = "session_created"
+    SESSION_RESET = "session_reset"
+    CONTEXT_SUMMARIZED = "context_summarized"
+
+    TOKEN_USAGE = "token_usage"
+
+    RESULT = "result"
+
+
+class TokenUsage(BaseModel):
+    """Per-call token accounting reported by an executor."""
+
+    model_config = ConfigDict(frozen=True)
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+    def __add__(self, other: TokenUsage) -> TokenUsage:
+        """Return the componentwise sum of two ``TokenUsage`` values.
+
+        Args:
+            other: The ``TokenUsage`` to add.
+
+        Returns:
+            A new ``TokenUsage`` whose fields are the sums of ``self`` and
+            ``other``.
+        """
+        ...
+
+
+def _new_id() -> EventId: ...
+
+
+class BaseEvent(BaseModel):
+    """Fields shared by every event appended through ``Coordinator.append_event``.
+
+    Concrete variants set ``kind`` to a distinct string value; downstream
+    consumers dispatch on ``kind`` and narrow to the corresponding
+    subclass.
+
+    Invariants:
+        I2.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: EventId = Field(default_factory=_new_id)
+    """Stable event id; never reused. Used as ``since_id`` cursor by
+    ``get_events``."""
+
+    timestamp: float = Field(default_factory=time.time)
+    """Wall-clock time of emission (``time.time()``)."""
+
+    thread_id: ThreadId | None = None
+    """Thread this event belongs to; both session id and subscription key.
+
+    Optional at construction: the worker's ``_route_event`` stamps the
+    routing thread id onto every event that flows through the worker
+    gate, so callers can omit it and rely on the runtime to fill it in.
+    Once an event has been persisted by a ``Coordinator`` (i.e. is
+    readable via ``get_events``), this field is guaranteed to be set.
+    ``Coordinator.append_event`` rejects unrouted events.
+    """
+
+    thread_name: str | None = None
+    """Display name for UIs; never consulted for correctness."""
+
+    message_id: MessageId | None = None
+    """Ties the fragments of a single assistant turn together."""
+
+
+# ── Thread lifecycle ──
+
+
+class StartedEvent(BaseEvent):
+    """Dispatcher has begun a cycle on this thread."""
+
+    kind: Literal[EventKind.STARTED] = EventKind.STARTED
+
+
+class CompletedEvent(BaseEvent):
+    """Cycle finished normally with a typed result."""
+
+    kind: Literal[EventKind.COMPLETED] = EventKind.COMPLETED
+
+
+class FailedEvent(BaseEvent):
+    """Cycle raised an uncaught exception."""
+
+    kind: Literal[EventKind.FAILED] = EventKind.FAILED
+    error: str
+    """``repr`` of the raised exception."""
+
+
+class CancelledEvent(BaseEvent):
+    """Cycle terminated cooperatively or was torn down."""
+
+    kind: Literal[EventKind.CANCELLED] = EventKind.CANCELLED
+
+
+# ── Conversation content ──
+
+
+class MessageUserEvent(BaseEvent):
+    """A user turn was appended to the conversation."""
+
+    kind: Literal[EventKind.MESSAGE_USER] = EventKind.MESSAGE_USER
+    text: str
+
+
+class MessageAssistantStartEvent(BaseEvent):
+    """Assistant turn began; subsequent events share its ``message_id``."""
+
+    kind: Literal[EventKind.MESSAGE_ASSISTANT_START] = EventKind.MESSAGE_ASSISTANT_START
+
+
+class MessageAssistantTokenEvent(BaseEvent):
+    """One streamed text chunk from the assistant.
+
+    Emitted once per ``data`` callback from Strands (i.e. once per
+    ``ContentBlockDeltaEvent`` with a text delta). The ``complete`` field
+    mirrors Strands' ``complete`` flag; when ``True`` this is the last
+    chunk of the current content block.
+    """
+
+    kind: Literal[EventKind.MESSAGE_ASSISTANT_TOKEN] = EventKind.MESSAGE_ASSISTANT_TOKEN
+    text: str
+    complete: bool = False
+
+
+class MessageAssistantThinkingEvent(BaseEvent):
+    """One streamed reasoning/thinking chunk from the assistant.
+
+    Emitted when the model returns a ``reasoningText`` delta via the
+    Strands callback handler (extended thinking / CoT models).
+    """
+
+    kind: Literal[EventKind.MESSAGE_ASSISTANT_THINKING] = EventKind.MESSAGE_ASSISTANT_THINKING
+    text: str
+    complete: bool = False
+
+
+class MessageAssistantCompleteEvent(BaseEvent):
+    """Assistant turn finished; closes the span opened by its ``message_id``.
+
+    ``content`` holds the full Strands-format content block list for the
+    turn, as returned by ``AfterModelCallEvent.stop_response.message``.
+    """
+
+    kind: Literal[EventKind.MESSAGE_ASSISTANT_COMPLETE] = EventKind.MESSAGE_ASSISTANT_COMPLETE
+    content: list[ContentBlock] = Field(default_factory=list[ContentBlock])
+    """Strands content blocks for the completed turn."""
+
+
+# ── Tool activity ──
+
+
+class ToolCallEvent(BaseEvent):
+    """A tool call is about to run, with its resolved arguments.
+
+    Emitted once per tool invocation just before the tool executes. The
+    full arguments dict is already materialized by the time Strands fires
+    ``BeforeToolCallEvent``. ``toolUse`` blocks in the preceding assistant
+    turn (``MessageAssistantCompleteEvent.content``) are what the
+    reconstructed message history relies on; this event is the
+    observability companion that tools and UIs subscribe to.
+    """
+
+    kind: Literal[EventKind.TOOL_CALL] = EventKind.TOOL_CALL
+    tool_use_id: str
+    tool_name: str
+    arguments: dict[str, object] = Field(default_factory=dict)
+
+
+class ToolResultEvent(BaseEvent):
+    """A tool call finished — either successfully or with an error.
+
+    Both outcomes share this event kind; ``status`` discriminates. The
+    field layout mirrors Strands'
+    :class:`strands.types.tools.ToolResult` (``{toolUseId, status,
+    content}``) at the top level of this event so consumers get typed
+    attribute access instead of string-keyed dict lookups.
+
+    On reconstruction, these three fields are packed back into a
+    ``ToolResult`` dict and splatted into a ``{"toolResult": ...}``
+    ``ContentBlock`` — the same shape Strands itself produces in its
+    event loop — so the cache prefix (I9) stays byte-identical.
+    """
+
+    kind: Literal[EventKind.TOOL_RESULT] = EventKind.TOOL_RESULT
+    tool_use_id: str
+    """Id of the ``toolUse`` block this result corresponds to."""
+    status: ToolResultStatus
+    """``"success"`` or ``"error"``, matching Strands' ``ToolResult.status``."""
+    content: list[ToolResultContent]
+    """Strands-format content blocks produced by the tool."""
+
+
+# ── Approvals ──
+
+
+class ApprovalRequestEvent(BaseEvent):
+    """Executor raised an interrupt requesting human approval for a tool call."""
+
+    kind: Literal[EventKind.APPROVAL_REQUEST] = EventKind.APPROVAL_REQUEST
+    approval_id: str
+    tool_name: str
+    arguments: dict[str, object] = Field(default_factory=dict)
+
+
+class ApprovalDecidedEvent(BaseEvent):
+    """A pending approval was resolved with a policy decision."""
+
+    kind: Literal[EventKind.APPROVAL_DECIDED] = EventKind.APPROVAL_DECIDED
+    approval_id: str
+    decision: str
+
+
+# ── Session management ──
+
+
+class SessionCreatedEvent(BaseEvent):
+    """A new thread / session was registered with the orchestrator."""
+
+    kind: Literal[EventKind.SESSION_CREATED] = EventKind.SESSION_CREATED
+
+
+class SessionResetEvent(BaseEvent):
+    """Session state for this thread was reset by the orchestrator."""
+
+    kind: Literal[EventKind.SESSION_RESET] = EventKind.SESSION_RESET
+
+
+class ContextSummarizedEvent(BaseEvent):
+    """Boundary in the event log: compacted history replaces everything before.
+
+    Emitted by the thread when its cumulative history is compacted
+    (either proactively or reactively on a
+    ``ContextWindowOverflowException``). The event marks a
+    cache-invalidation point for I9: on the next reconstruction, every
+    event strictly before this one (in append order) is dropped from the
+    rendered history and ``new_history`` is rendered in its place.
+    Events strictly after render normally.
+
+    The payload is a synthetic sequence of conversational events — the
+    same event shapes the thread would normally emit during a cycle —
+    constructed by the :class:`SummarizationStrategy`.
+
+    Invariants:
+        - I9 — this event is the canonical cache-invalidation marker.
+        - I10 — the strategy is responsible for producing a history whose
+          ``toolUse`` / ``toolResult`` pairs are legal; the reconstruction
+          healer is a safety net, not the primary contract.
+    """
+
+    kind: Literal[EventKind.CONTEXT_SUMMARIZED] = EventKind.CONTEXT_SUMMARIZED
+
+    new_history: list[RenderableEvent] = Field(default_factory=list["RenderableEvent"])
+    """The compacted history that replaces every event before this one.
+
+    Rendered by ``reconstruct_messages`` in place of the preceding event
+    sequence. The events are interpreted exactly as if they had been
+    emitted during a normal cycle.
+
+    Requires:
+        - The first event (when present) has ``role == "user"`` semantics
+          in the rendered view — most providers reject a message sequence
+          that starts with an assistant turn.
+        - Every ``toolUse`` block reachable through these events has a
+          matching ``toolResult`` event later in ``new_history`` or gets
+          healed by :func:`reconstruct_messages` (I10).
+    """
+
+
+# ── Resource usage ──
+
+
+class TokenUsageEvent(BaseEvent):
+    """Token usage reported for one model call."""
+
+    kind: Literal[EventKind.TOKEN_USAGE] = EventKind.TOKEN_USAGE
+    token_usage: TokenUsage
+
+
+# ── Result ──
+
+
+class ResultEvent(BaseEvent):
+    """The serialized result of a completed cycle.
+
+    Emitted by the runtime dispatcher immediately after any successful
+    cycle, before the matching ``CompletedEvent``. The payload is produced
+    by ``Thread.serialize_result`` and can be recovered by calling
+    ``Thread.deserialize_result(event.payload)``.
+
+    Invariants:
+        I5 — lifecycle events (``STARTED``, ``COMPLETED``, ``CANCELLED``,
+        ``FAILED``, ``RESULT``) are emitted only by the runtime dispatcher
+        that drives ``Thread.execute``/``resume``. ``Thread``
+        implementations must not emit them directly.
+    """
+
+    kind: Literal[EventKind.RESULT] = EventKind.RESULT
+    payload: str
+    """Thread-serialized result; opaque to the runtime and coordinator."""
+
+
+# ── User-defined extension ──
+
+
+class CustomEvent(BaseModel):
+    """Catch-all event for user-defined ``kind`` values.
+
+    A ``mode="before"`` validator reshapes flat input dicts: all keys
+    other than declared model fields land inside ``payload``. A
+    ``model_serializer`` flattens on the way out, so the wire format
+    round-trips through pydantic.
+
+    If ``payload`` is provided explicitly, any extra top-level keys are
+    merged into it (extras take precedence over explicit-payload entries
+    that have the same key). Known declared fields on subclasses (if any)
+    are preserved as-is and not swept into ``payload``.
+    """
+
+    kind: str
+    payload: dict[str, object] = Field(default_factory=dict[str, object])
+
+
+# ── Discriminated union ──
+
+SystemEvent = Annotated[
+    StartedEvent | CompletedEvent | FailedEvent | CancelledEvent | MessageUserEvent |
+    MessageAssistantStartEvent | MessageAssistantTokenEvent | MessageAssistantThinkingEvent |
+    MessageAssistantCompleteEvent |
+    ToolCallEvent | ToolResultEvent |
+    ApprovalRequestEvent | ApprovalDecidedEvent | SessionCreatedEvent | SessionResetEvent | ContextSummarizedEvent |
+    TokenUsageEvent | ResultEvent,
+    Field(discriminator="kind")
+]
+
+Event = SystemEvent | CustomEvent
+"""Tagged union of every built-in event variant plus the ``CustomEvent`` fallback.
+
+Pydantic tries union members left-to-right (with the discriminated union
+as a single fast-path attempt first). If ``kind`` does not match any
+``SystemEvent``, it falls through to ``CustomEvent``, whose
+``model_validator(mode="before")`` reshapes the raw dict into
+``{kind, payload}``.
+
+Users can write their own union to add correct parsing of their own
+event types.
+"""
+
+
+# ── Renderable subset ──
+
+RenderableEvent = (
+    MessageUserEvent
+    | MessageAssistantCompleteEvent
+    | ToolCallEvent
+    | ToolResultEvent
+)
+"""Events that may appear inside a ``ContextSummarizedEvent.new_history``.
+
+Restricted to the event kinds that carry conversational content:
+
+- :class:`MessageUserEvent`, :class:`MessageAssistantCompleteEvent` —
+  turns.
+- :class:`ToolCallEvent`, :class:`ToolResultEvent` — tool activity.
+  ``ToolCallEvent`` is observability-only but included for completeness:
+  a strategy may replay it to preserve the original timeline in a UI,
+  even though it contributes no message.
+
+Explicitly excluded:
+
+- Lifecycle events (``STARTED`` / ``COMPLETED`` / ``FAILED`` /
+  ``CANCELLED``), ``ResultEvent``, ``TokenUsageEvent``, session events,
+  approval events.
+- Streaming-fragment events — aggregated by
+  ``MessageAssistantCompleteEvent``.
+- ``ContextSummarizedEvent`` itself.
+- ``CustomEvent`` — inert to reconstruction.
+"""
+
+
+def is_renderable_event(event: Event) -> TypeGuard[RenderableEvent]:
+    """Return whether ``event`` is a :data:`RenderableEvent`.
+
+    Self-maintaining: the concrete types are derived from
+    :data:`RenderableEvent` via :func:`typing.get_args`, so widening the
+    union automatically widens this guard.
+
+    Args:
+        event: Any :data:`Event` instance.
+
+    Returns:
+        ``True`` iff ``event`` is an instance of one of the union's
+        concrete variants.
+    """
+    ...

--- a/spec/ai_functions/types/ids.pyi
+++ b/spec/ai_functions/types/ids.pyi
@@ -1,0 +1,17 @@
+"""Semantic ``NewType`` aliases for opaque string identifiers."""
+
+from __future__ import annotations
+
+from typing import NewType
+
+ThreadId = NewType("ThreadId", str)
+"""Runtime-assigned identifier for a registered thread."""
+
+EventId = NewType("EventId", str)
+"""Stable event id; never reused; used as the ``since_id`` cursor."""
+
+MessageId = NewType("MessageId", str)
+"""Ties the fragments of a single assistant turn together."""
+
+WorkerId = NewType("WorkerId", str)
+"""Server-assigned identifier for a ``WorkerProcess``."""

--- a/spec/ai_functions/types/policy.pyi
+++ b/spec/ai_functions/types/policy.pyi
@@ -1,0 +1,19 @@
+"""Tool-permission policy alias."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+Policy = Literal["allow_always", "deny", "prompt", "allow_session"]
+"""Effective policy for a tool call.
+
+``allow_always``
+    The tool may run without an approval request.
+``deny``
+    The tool call is refused without prompting.
+``prompt``
+    An ``APPROVAL_REQUEST`` is emitted and the executor awaits a decision.
+``allow_session``
+    Allowed for the current session (see ``PermissionStore.grant_session`` /
+    ``revoke_session``).
+"""

--- a/spec/ai_functions/types/status.pyi
+++ b/spec/ai_functions/types/status.pyi
@@ -1,0 +1,105 @@
+"""Runtime-maintained lifecycle status for registered threads."""
+
+from __future__ import annotations
+
+import enum
+from pydantic import BaseModel
+
+from .ids import ThreadId, WorkerId
+
+
+class ThreadStatus(enum.StrEnum):
+    """Runtime-maintained lifecycle state of a registered thread.
+
+    Lifecycle:
+        NOT_STARTED -> RUNNING -> {IDLE, PAUSED, CANCELLED} -> {TERMINATED, FAILED}.
+    """
+
+    NOT_STARTED = "not_started"
+    """Thread is registered; no cycle has run yet."""
+
+    RUNNING = "running"
+    """Dispatcher is currently awaiting ``Thread.execute``."""
+
+    IDLE = "idle"
+    """Dispatcher is blocked on an empty queue after at least one cycle."""
+
+    PAUSED = "paused"
+    """Pause signal is set; queued work is not consumed until resume."""
+
+    CANCELLED = "cancelled"
+    """Last cycle ended via cooperative cancel; thread stays registered."""
+
+    TERMINATED = "terminated"
+    """Thread has been torn down; handle is no longer usable. Terminal."""
+
+    FAILED = "failed"
+    """Runtime removed the thread after an unrecoverable failure. Terminal."""
+
+    @property
+    def is_done(self) -> bool:
+        """Whether this status is terminal.
+
+        Returns:
+            ``True`` iff the thread has been removed from the runtime.
+        """
+        ...
+
+
+class InputShape(enum.StrEnum):
+    """Coarse classification of a thread's ``execute`` input signature.
+
+    Fine enough for the runtime-facing LLM tools to decide whether a
+    thread is "chat-shaped" (accepts one string), fine-grained typed,
+    or takes no arguments. Not intended to describe the full signature —
+    if callers need structural detail, they should add a separate
+    ``input_schema`` field in a later revision.
+    """
+
+    STR_PROMPT = "str_prompt"
+    """Thread takes exactly one positional ``str`` argument.
+
+    Chat-style peers; eligible for ``send_message`` tool invocations.
+    """
+
+    STRUCTURED = "structured"
+    """Thread takes one or more typed positional arguments that are not
+    ``str``. Not eligible for the default ``send_message`` tool; callers
+    must invoke the thread through its typed ``run`` entry point."""
+
+    NO_ARGS = "no_args"
+    """Thread takes no positional arguments — a pure one-shot."""
+
+
+class ThreadInfo(BaseModel):
+    """Static snapshot of a thread's identity, host, and current status.
+
+    Produced by :meth:`Coordinator.list_threads` and
+    :meth:`Coordinator.get_thread_info` for discovery and introspection
+    — both by application code and by the runtime-facing tools exposed
+    to LLM agents. Pydantic frozen model so it round-trips over the
+    wire via ``model_dump_json`` / ``model_validate_json``.
+    """
+
+    thread_id: ThreadId
+    """Runtime-assigned id of this thread."""
+
+    worker_id: WorkerId
+    """Id of the worker that hosts this thread. The coordinator uses
+    this to route operations via the worker's ``WorkerAdapter``."""
+
+    thread_name: str | None
+    """Human-readable name supplied at spawn time (may be ``None``)."""
+
+    input_shape: InputShape
+    """Coarse shape of the thread's ``execute`` input signature.
+
+    Provided by the thread at spawn time; never changes over the
+    thread's lifetime.
+    """
+
+    status: ThreadStatus
+    """Runtime-maintained lifecycle status of this thread at snapshot time."""
+
+    parent_id: ThreadId | None = None
+    """Id of the parent thread, if this thread was spawned with one."""

--- a/spec/ai_functions/utils.pyi
+++ b/spec/ai_functions/utils.pyi
@@ -1,0 +1,36 @@
+"""Blocking bridge between sync callers and ``async def`` code."""
+
+from collections.abc import Awaitable, Callable
+
+
+def run_blocking[T](coro_factory: Callable[[], Awaitable[T]]) -> T:
+    """Run ``coro_factory()`` to completion and return its result.
+
+    The factory is invoked exactly once, inside an event loop owned by
+    this call. If the caller is not currently inside a running event
+    loop, a loop is started via ``asyncio.run`` on the calling thread;
+    otherwise a worker thread is used so the nested ``asyncio.run`` does
+    not clash with the outer loop. In both cases the calling thread
+    blocks until the coroutine finishes.
+
+    ``coro_factory`` is a factory rather than a pre-built coroutine so
+    the awaitable is constructed inside the target loop; pre-building in
+    one loop and awaiting in another is a runtime error in ``asyncio``.
+
+    Args:
+        coro_factory: Zero-argument callable returning a fresh awaitable.
+
+    Returns:
+        The value awaited from the coroutine.
+
+    Raises:
+        BaseException: Any exception raised by the awaited coroutine is
+            re-raised unchanged on the calling thread.
+
+    Concurrency:
+        Blocks the calling thread. Safe to call from both sync contexts
+        and from within a running event loop (the work is dispatched to a
+        worker thread in the latter case). ``contextvars`` are copied
+        into the worker thread so framework-managed context is preserved.
+    """
+    ...

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -1,0 +1,36 @@
+# PEP 695 generics create __type_params__ at runtime; not representable in stubs
+ai_functions.ai_thread.ai_function.AIFunction.__type_params__
+ai_functions.ai_thread.ai_thread.AIThread.__type_params__
+ai_functions.ai_thread.ai_thread.OutputSpec.__type_params__
+ai_functions.handle.ThreadHandle.__type_params__
+ai_functions.runtime.worker.PromptRequest.__type_params__
+ai_functions.protocols.Spawnable.__type_params__
+ai_functions.protocols.Thread.__type_params__
+
+# Annotated[Union[...], Field(...)] aliases are callable _AnnotatedAlias at runtime, not Union types
+ai_functions.network.wire.Binary
+ai_functions.network.wire.Frame
+ai_functions.types.events.SystemEvent
+ai_functions.types.policy.Policy
+
+# NewType creates functions at runtime; stubs declare them as classes (TypeInfo)
+ai_functions.types.ids.EventId
+ai_functions.types.ids.MessageId
+ai_functions.types.ids.ThreadId
+ai_functions.types.ids.WorkerId
+
+# pydantic mangles __context in model_post_init; not our concern
+ai_functions.ai_thread.postcondition.PostConditionResult.model_post_init
+
+# CoordinatorHandlers / WorkerHandlers are dispatch tables for the wire
+# layer. Each public method is a @rpc_method-decorated handler; the stub
+# declares only the class signatures (the methods are internal machinery
+# discovered by bind_handlers via introspection, not a user-facing API).
+ai_functions.network.client.WorkerHandlers.*
+ai_functions.network.endpoint.CoordinatorHandlers.*
+
+# wire_methods.py is a collection of per-RPC pydantic request models.
+# Their shapes are implementation details of the wire protocol; the spec
+# documents the RPC surface in channel.pyi / client.pyi / endpoint.pyi
+# rather than duplicating every params model in a stub file.
+ai_functions.network.wire_methods


### PR DESCRIPTION
Adds a spec/ directory of .pyi type stubs mirroring the public API of ai_functions, plus a stubtest-allowlist.txt and a check-spec hatch script to verify them. check-spec passes clean (no issues across 34 modules). Purely additive — no runtime changes.