### PR TITLE
fix(examples): rename secret_greeting -> special_greeting to clear Co…

### DIFF
--- a/examples/memory_procedural.py
+++ b/examples/memory_procedural.py
@@ -14,7 +14,7 @@ define the code in the execution environment.
 
 This example is also a live check of the code-execution *advertisement*: the
 runtime tells the agent which helpers are already defined — by signature and
-docstring — so the task prompts never name ``secret_greeting`` or spell out how
+docstring — so the task prompts never name ``special_greeting`` or spell out how
 to call it. The second turn proves both that the seed helper survives the
 optimizer's rewrite and that the advertisement is enough for the model to find
 and call it unaided (the greeting's code is non-guessable, so a correct answer
@@ -51,8 +51,8 @@ class Schema(BaseModel):
     # helper without the prompt naming it.
     helper_functions: Procedural = Field(
         default=(
-            "def secret_greeting(name):\n"
-            '    """Return a special secret greeting, use only if requested."""\n'
+            "def special_greeting(name):\n"
+            '    """Return a special greeting, use only if requested."""\n'
             "    return f'Zphqr, {name}! (code 7731)'\n"
         ),
         description="Reusable Python helper functions available to the agent.",
@@ -66,7 +66,7 @@ async def main(path: str | Path) -> None:
     display("Initial Procedural Memory", str(memory))
 
     # Turn 1: an open-ended task that the seed code does not directly solve.
-    # Only `secret_greeting` is defined, so the run exercises the environment;
+    # Only `special_greeting` is defined, so the run exercises the environment;
     # feedback then grows the stored code into reusable multi-language helpers.
     result = await run_task.trace(
         task="Greet Alice in Spanish.",
@@ -85,18 +85,18 @@ async def main(path: str | Path) -> None:
     display("Updated Procedural Memory", str(memory))
 
     # Turn 2: does the seed helper survive, and can the agent find it unaided?
-    # We recall the *updated* code and ask for the secret greeting WITHOUT naming
+    # We recall the *updated* code and ask for the special greeting WITHOUT naming
     # the function or its signature. The agent has to read the advertised helper
-    # signatures + docstrings to pick secret_greeting; a correct, non-guessable
+    # signatures + docstrings to pick special_greeting; a correct, non-guessable
     # answer proves both that it survived consolidation and that the
     # advertisement works.
-    secret = await run_task.trace(
-        task="Return the caller's personal secret greeting for the name 'Bob', exactly as the helper produces it.",
+    special_greeting = await run_task.trace(
+        task="Return the caller's special greeting for the name 'Bob', exactly as the helper produces it.",
         helper_functions=await memory.recall("helper_functions"),
     )
-    display("Turn 2 Result (expected to contain 'Zphqr, Bob! (code 7731)')", str(secret))
-    ok = "Zphqr, Bob! (code 7731)" in str(secret)
-    display("secret_greeting survived and was found via the advertisement", str(ok), lang="text")
+    display("Turn 2 Result (expected to contain 'Zphqr, Bob! (code 7731)')", str(special_greeting))
+    ok = "Zphqr, Bob! (code 7731)" in str(special_greeting)
+    display("special_greeting survived and was found via the advertisement", str(ok), lang="text")
 
     memory.close()
 


### PR DESCRIPTION
rename `secret_greeting` -> `special_greeting` to clear CodeQL false positive

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
