### PR TITLE
docs: add "Threads are a protocol" section (ClaudeAgent / KiroAgent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Strands AI Functions is a Python library built around a new abstraction: functio
 - **[Native Python objects](#native-python-objects)**: agents can dynamically generate and execute code, so an AI Function can take and return real Python values (a `DataFrame`, not a JSON blob).
 - **[Just functions](#composing-functions)**: run them in parallel with `asyncio.gather`, pass them to other agents as tools, and share them as ordinary Python libraries.
 - **[Stateful threads and teams](#stateful-ai-threads)**: spawn a function into a live **AI Thread** that keeps its history; run several threads on a coordinator and let them discover and message each other.
+- **[One team, many runtimes](#threads-are-a-protocol-claude-code-kiro-or-your-own)**: threads implement a common protocol, so any agent runtime can join a team; wrappers for Claude Code and Kiro ship in the box and are discovered, messaged, and orchestrated exactly like native threads.
 - **[Distributed by a one-line change](#distributed-operation)**: swap the in-process coordinator for a client, and the same code runs across processes and machines.
 - **[Memory and optimization](#memory--optimization)**: backpropagation-style natural-language feedback updates the prompts, facts, and code your workflow relies on, so it continuously improves.
 
@@ -259,6 +260,29 @@ if __name__ == "__main__":
 ```
 
 `send_message` supports three modes: `"wait"` (block on the peer's reply), `"fire_and_forget"` (schedule and return immediately), and `"continue_then_receive"` (dispatch, end the current cycle, and resume automatically when the reply arrives). Children spawned with `parent_id` have their token usage roll up to the parent, and every turn, tool call, and lifecycle transition is available as an event stream via `coordinator.on(...)`. Orchestration logic that is not naturally expressed as a single prompt can be written as a custom **Spawnable**: a plain-Python workflow that runs as a thread and spawns AI subagents of its own. See the [tutorial](docs/tutorial.md) for all of these.
+
+## Threads Are a Protocol: Claude Code, Kiro, or Your Own
+
+An AI Function is only one implementation of the thread contract. Anything that implements the small `Spawnable` protocol can be hosted by a worker, and every implementation gets the full runtime surface: peers discover it with `list_threads` and delegate to it with `send_message`, orchestrators drive it through the same handle and lifecycle, its activity streams into the same event log, and post-conditions validate its results. The library ships two implementations that wrap external agent runtimes: `ClaudeAgent` runs a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session (via the Claude Agent SDK) and `KiroAgent` runs a [Kiro](https://kiro.dev) session (via the Agent Client Protocol). The external runtime keeps its own conversation and tools; to the rest of the team, it is a thread like any other.
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions
+
+from ai_functions.claude_code import ClaudeAgent
+from ai_functions.runtime import InMemoryCoordinator, LocalWorker
+
+coord = InMemoryCoordinator()
+worker = await LocalWorker(coord).register()
+
+# A Claude Code session as a thread, next to the AI Functions from the previous section.
+coder = await worker.spawn_locally(ClaudeAgent(options=ClaudeAgentOptions()), thread_name="coder")
+_ = await coord.spawn(researcher, thread_name="researcher")
+
+# Same handle API, same events, same peer messaging.
+result = await coder.run("Profile src/parser.py and fix the hot spot. Ask `researcher` for the algorithm.")
+```
+
+The Claude session is even given the coordinator's `list_threads` / `send_message` tools (bridged in over MCP), so it can delegate to its teammates on its own, exactly like a native thread. Backends ship as extras (`pip install 'strands-ai-functions[claude-code]'` or `[kiro]`); see the [tutorial](docs/tutorial.md#threads-as-a-protocol-claude-code-and-kiro) and the runnable `examples/integrate_claude_code.py` and `examples/integrate_kiro.py`.
 
 ## Distributed Operation
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -19,6 +19,7 @@ Because AI Functions *are* functions, developers can construct agentic workflows
 - [Parallel workflows](#parallel-workflows)
 - [AI Threads: adding state](#ai-threads-adding-state)
 - [Teams of agents: the coordinator and workers](#teams-of-agents-the-coordinator-and-workers)
+- [Threads as a protocol: Claude Code and Kiro](#threads-as-a-protocol-claude-code-and-kiro)
 - [Events and observability](#events-and-observability)
 - [Memory and optimization](#memory-and-optimization)
 - [Distributed operation](#distributed-operation)
@@ -788,6 +789,48 @@ sequenceDiagram
 Application code has an equivalent, code-facing side channel: `handle.notify(text)`, described in [AI Threads](#ai-threads-adding-state), routes out-of-band context to any registered thread without starting a cycle.
 
 For a complete runnable example exercising all three `send_message` modes, see `examples/team_two_workers_local.py`.
+
+## Threads as a protocol: Claude Code and Kiro
+
+The threads on a coordinator do not all have to be AI Functions. A thread is a generic contract: any object implementing the `Spawnable` protocol (a factory producing a live thread; see [Going further](#going-further)) can be hosted by a worker, which is how foreign agent runtimes gain interoperability with everything in the previous sections. The library ships two such implementations:
+
+- **`ClaudeAgent`** (`ai_functions.claude_code`) drives a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) session through the Claude Agent SDK. Requires the `claude-code` extra: `pip install 'strands-ai-functions[claude-code]'`.
+- **`KiroAgent`** (`ai_functions.kiro`) drives a [Kiro](https://kiro.dev) session over the Agent Client Protocol (ACP). Requires the `kiro` extra and the `kiro-cli` binary on your `PATH`.
+
+In both cases the external runtime owns the conversation and its own tools (file access, shell, editing); the library observes the session and re-emits everything it does as standard events. To the coordinator, an external-backend thread is a thread like any other. The whole runtime surface from the previous sections applies unchanged:
+
+- peers discover it with `list_threads` and delegate to it with `send_message`;
+- an orchestrator drives it through the same `ThreadHandle` (`run`, `notify`, lifecycle control);
+- its turns, tool calls, and token usage stream into the same event log (`coordinator.on(...)`, `get_events`);
+- `post_conditions` on the template validate each result, with the same self-correcting retry loop AI Functions use.
+
+Spawning one looks exactly like spawning an AI Function, except the template is constructed rather than decorated:
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions
+
+from ai_functions.claude_code import ClaudeAgent
+from ai_functions.runtime import InMemoryCoordinator, LocalWorker
+
+coord = InMemoryCoordinator()
+worker = await LocalWorker(coord).register()
+
+template = ClaudeAgent(options=ClaudeAgentOptions(), name="coder")
+handle = await worker.spawn_locally(template, thread_name="coder")
+
+result = await handle.run("Find the three .md files in this directory and summarize the project.")
+```
+
+`spawn_locally` hosts the thread on this worker without serializing the template across the wire, which is the natural choice for a thread that drives a local subprocess. A `KiroAgent` spawns the same way (`KiroAgent(name="kiro")`; see its `executable` and `auto_approve` options).
+
+Two practical notes:
+
+- **Permissions.** Both runtimes ask for approval before running tools. Non-interactive scripts can bypass this (`ClaudeAgentOptions(permission_mode="bypassPermissions")`; `KiroAgent(auto_approve=True)`, the default); otherwise approval requests are routed through the thread's interrupt channel. Only bypass approvals in trusted environments.
+- **Delegation from inside the session.** A `ClaudeAgent` session is also given the coordinator's `list_threads` / `send_message` tools, bridged in over MCP, so the Claude session can discover teammates and delegate to them on its own, exactly like a native thread.
+
+See `examples/integrate_claude_code.py` and `examples/integrate_kiro.py` for complete runnable versions, including rendering the event stream of an external session.
+
+Wrapping a foreign runtime is one use of the protocol; the same contract also admits plain-Python workflows that run as threads and orchestrate AI subagents of their own — see [Going further](#going-further) and the [architecture documentation](architecture.md#custom-spawnables) for implementing your own.
 
 ## Events and observability
 


### PR DESCRIPTION
Document that any Spawnable can join a coordinator as a thread, and that the library ships ClaudeAgent (Claude Code) and KiroAgent (Kiro) wrappers that are discovered, messaged, and orchestrated like native threads.

- README: new feature bullet + a "Threads Are a Protocol" section with a ClaudeAgent spawn example.
- tutorial: new "Threads as a protocol" section (TOC entry, spawn example, permissions + in-session delegation notes) linking the runnable examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
