### PR TITLE
Add minimal GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,25 @@
+name: Bug report
+description: Report something that isn't working as expected.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect instead? Include the command you ran and the full error message or traceback if you have one.
+      placeholder: |
+        Running `...` produces `...`, but I expected `...`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in whatever is relevant.
+      value: |
+        - strands-ai-functions version:
+        - Python version:
+        - OS:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security issue
+    url: http://aws.amazon.com/security/vulnerability-reporting/
+    about: Please report security vulnerabilities here, not as a public issue.
+  - name: Question or discussion
+    url: https://github.com/strands-labs/ai-functions/discussions
+    about: Ask questions and discuss ideas with the community.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,11 @@
+name: Feature request
+description: Suggest an idea or improvement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: request
+    attributes:
+      label: What would you like to see?
+      description: Describe the feature or improvement, and the problem it would solve for you.
+    validations:
+      required: true


### PR DESCRIPTION
## Description

Adds GitHub issue templates, addressing #31.

Kept deliberately minimal so reporters aren't forced to fill in fields we won't use to debug:

- **`bug_report.yml`** — one required field ("What happened?", which prompts for the command + error/traceback) and an optional Environment block (version / Python / OS).
- **`feature_request.yml`** — a single free-form field.
- **`config.yml`** — routes security reports to the AWS vulnerability reporting page (per CONTRIBUTING.md) and questions to GitHub Discussions. Blank issues remain enabled.

## Testing

- All three YAML files validated with `yaml.safe_load`.
- Confirmed GitHub Discussions is enabled on the repo, so the contact link resolves.

Closes #31