### PR TITLE
refactor(tools): share one core for list_threads / send_message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ uv.lock
 site/
 .cache/
 
+# local code-intelligence index and vendored reference sources
+.codegraph/
+.vendor/
+
 # screenshot generation scratch
 .screenshots/
 .DS_Store

--- a/spec/ai_functions/ai_thread/tools.pyi
+++ b/spec/ai_functions/ai_thread/tools.pyi
@@ -6,26 +6,12 @@ The default ``config_hook`` installed on every ``AIFunction`` calls
 :func:`coordinator_tools` with the cycle's ``ctx`` and appends the
 result to ``cycle_config.tools``.
 
-Two tools are exposed:
-
-- ``list_threads()`` — return a JSON-friendly snapshot of every thread
-  registered with the calling agent's coordinator, including a
-  ``is_self`` flag marking the calling thread.
-- ``send_message(thread_id, message, mode="wait")`` — invoke a peer
-  thread via its typed ``run(message)`` entry point. The peer must have
-  ``input_shape == STR_PROMPT``. ``mode`` selects how the sender relates
-  to the peer's result:
-
-  - ``"wait"`` (default): await the peer's cycle; return its reply as
-    the tool's result. Blocks the sender's cycle on the peer's cycle.
-  - ``"fire_and_forget"``: schedule the peer's cycle as a background
-    task; return immediately. The peer's reply is discarded.
-  - ``"continue_then_receive"``: schedule the peer's cycle, return
-    immediately, and when the peer completes, enqueue a fresh cycle on
-    the sender with the peer's reply formatted as the user turn. This
-    mode requires the sender itself to have ``input_shape == STR_PROMPT``
-    — the tool returns an error otherwise, asking the agent to use
-    ``"wait"``.
+Two tools are exposed, ``list_threads()`` and
+``send_message(thread_id, message, mode="wait")``. Their semantics, wire
+descriptions, and argument schema live in
+:mod:`ai_functions.runtime.coordinator_tools_core` so that every runtime adapter
+offers the identical tool; this module is the Strands binding for them, and
+Strands derives each schema from the wrapper's signature.
 
 These tools are LLM-facing. Application code that wants the old
 inject-then-no-cycle semantics should call

--- a/spec/ai_functions/claude_code/coordinator_tools.pyi
+++ b/spec/ai_functions/claude_code/coordinator_tools.pyi
@@ -1,21 +1,17 @@
 """Runtime-facing tools exposed to a Claude Agent SDK session.
 
-Mirror of :mod:`ai_functions.ai_thread.tools` for the Claude Agent runtime.
+Claude Agent SDK binding for the two runtime-facing tools.
 ``coordinator_tools(ctx)`` returns a ``Sequence[SdkMcpTool]`` that can
 be packaged via :func:`runtime_mcp_server` into the
 ``McpSdkServerConfig`` consumed by ``ClaudeAgentOptions.mcp_servers``.
 
-Two tools are exposed:
-
-- ``list_threads()`` — return a JSON-friendly snapshot of every thread
-  registered with the calling agent's coordinator, including a
-  ``is_self`` flag marking the calling thread.
-- ``send_message(thread_id, message, mode="wait")`` — invoke a peer
-  thread via its typed ``run(message)`` entry point. The peer must
-  have ``input_shape == STR_PROMPT``. ``mode`` selects how the sender
-  relates to the peer's result, with the same ``"wait"`` /
-  ``"fire_and_forget"`` / ``"continue_then_receive"`` semantics as
-  the Strands-side ``send_message``.
+The tools are ``list_threads()`` and
+``send_message(thread_id, message, mode="wait")``. Their semantics, wire
+descriptions, and argument schemas live in
+:mod:`ai_functions.runtime.coordinator_tools_core`, shared with the Strands
+binding in :mod:`ai_functions.ai_thread.tools`, so an agent sees the same tool
+whichever runtime hosts it. This module adds only the SDK decorator and the MCP
+content packing.
 
 The MCP server reserves the name ``_ai_functions_runtime`` in the
 ``mcp_servers`` mapping. Users may not register their own server

--- a/spec/ai_functions/runtime/coordinator_tools_core.pyi
+++ b/spec/ai_functions/runtime/coordinator_tools_core.pyi
@@ -31,7 +31,6 @@ __all__ = [
     "SEND_MESSAGE_DESCRIPTION",
     "SEND_MESSAGE_INPUT_SCHEMA",
     "SEND_MESSAGE_MODES",
-    "ListThreadsArgs",
     "ListThreadsResult",
     "SendMessageArgs",
     "SendMessageMode",
@@ -53,7 +52,11 @@ SEND_MESSAGE_DESCRIPTION: str
 """Wire-visible description of ``send_message``, shared by every adapter."""
 
 LIST_THREADS_INPUT_SCHEMA: dict[str, Any]
-"""JSON Schema for ``list_threads``, for adapters whose SDK takes one directly."""
+"""JSON Schema for ``list_threads``, for adapters whose SDK takes one directly.
+
+Written out rather than derived from a model: the tool takes no arguments, so
+there is nothing for a second declaration to drift from.
+"""
 
 SEND_MESSAGE_INPUT_SCHEMA: dict[str, Any]
 """JSON Schema for ``send_message``, for adapters whose SDK takes one directly.
@@ -63,25 +66,47 @@ enum with a default rather than as a bare string.
 """
 
 class ThreadSummary(BaseModel):
-    """One entry of :class:`ListThreadsResult`; a JSON-friendly ``ThreadInfo``."""
+    """One entry of :class:`ListThreadsResult`; an agent-facing ``ThreadInfo``.
+
+    Every field is widened to ``str`` because this crosses a tool boundary to a
+    language model: :class:`~ai_functions.types.ThreadInfo` carries ``ThreadId``
+    newtypes and ``StrEnum`` members, and a model reading the tool result has no
+    use for that distinction. Frozen, like ``ThreadInfo``, so it round-trips over
+    the wire via ``model_dump_json`` / ``model_validate_json``.
+    """
 
     thread_id: str
+    """Runtime-assigned id of this thread; the value to pass to ``send_message``."""
+
     thread_name: str | None
+    """Human-readable name supplied at spawn time (may be ``None``)."""
+
     status: str
+    """Lifecycle status of this thread at snapshot time."""
+
     input_shape: str
+    """Coarse shape of the thread's ``execute`` input signature. Only
+    ``"str_prompt"`` threads can receive ``send_message``."""
+
     parent_id: str | None
+    """Id of the parent thread, if this thread was spawned with one."""
+
     is_self: bool
+    """True for the thread whose agent is calling the tool."""
 
 class ListThreadsResult(BaseModel):
-    """Return shape of :func:`list_threads`."""
+    """Return shape of :func:`list_threads`. Frozen; serialises via ``model_dump_json``."""
 
     threads: list[ThreadSummary]
-
-class ListThreadsArgs(BaseModel):
-    """Arguments of :func:`list_threads` — there are none."""
+    """One entry per thread registered with the coordinator, order coordinator-defined."""
 
 class SendMessageArgs(BaseModel):
-    """Arguments of :func:`send_message`; the sole declaration of its schema."""
+    """Arguments of :func:`send_message`; the sole declaration of its schema.
+
+    Exists to be rendered as a schema rather than to be instantiated: adapters
+    whose SDK wants a JSON Schema get :data:`SEND_MESSAGE_INPUT_SCHEMA` from it,
+    and adapters that infer from a signature declare the same three parameters.
+    """
 
     thread_id: str
     message: str

--- a/spec/ai_functions/runtime/coordinator_tools_core.pyi
+++ b/spec/ai_functions/runtime/coordinator_tools_core.pyi
@@ -1,0 +1,137 @@
+"""Transport-agnostic bodies for the two runtime-facing coordinator tools.
+
+Every runtime adapter that exposes ``list_threads`` / ``send_message`` to an
+agent — the Strands-native path in :mod:`ai_functions.ai_thread.tools` and the
+Claude Agent SDK MCP path in :mod:`ai_functions.claude_code.coordinator_tools` —
+calls into this module. Adapters own only their transport's plumbing (decorator,
+schema handoff, result packing); the semantics, the wire-visible descriptions,
+the argument schemas, and the deadlock guard live here once so no two agents can
+be offered different versions of the same tool.
+
+The bodies take ``(coordinator, self_thread_id)`` rather than a
+:class:`~ai_functions.types.ThreadContext`, because that pair is all they need.
+An adapter with no live cycle to draw a context from can therefore still serve
+the tools.
+
+Schemas are derived, never written twice: :class:`SendMessageArgs` is the single
+declaration of ``send_message``'s arguments, and adapters either bind their
+decorator to a matching signature or hand :data:`SEND_MESSAGE_INPUT_SCHEMA`
+straight to their SDK.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from ..protocols import Coordinator
+
+__all__ = [
+    "LIST_THREADS_DESCRIPTION",
+    "LIST_THREADS_INPUT_SCHEMA",
+    "SEND_MESSAGE_DESCRIPTION",
+    "SEND_MESSAGE_INPUT_SCHEMA",
+    "SEND_MESSAGE_MODES",
+    "ListThreadsArgs",
+    "ListThreadsResult",
+    "SendMessageArgs",
+    "SendMessageMode",
+    "ThreadSummary",
+    "list_threads",
+    "send_message",
+]
+
+SendMessageMode = Literal["wait", "fire_and_forget", "continue_then_receive"]
+"""How the sender relates to the peer's result."""
+
+SEND_MESSAGE_MODES: tuple[str, ...]
+"""The legal :data:`SendMessageMode` values, for runtime validation."""
+
+LIST_THREADS_DESCRIPTION: str
+"""Wire-visible description of ``list_threads``, shared by every adapter."""
+
+SEND_MESSAGE_DESCRIPTION: str
+"""Wire-visible description of ``send_message``, shared by every adapter."""
+
+LIST_THREADS_INPUT_SCHEMA: dict[str, Any]
+"""JSON Schema for ``list_threads``, for adapters whose SDK takes one directly."""
+
+SEND_MESSAGE_INPUT_SCHEMA: dict[str, Any]
+"""JSON Schema for ``send_message``, for adapters whose SDK takes one directly.
+
+Derived from :class:`SendMessageArgs`, so ``mode`` reaches every runtime as an
+enum with a default rather than as a bare string.
+"""
+
+class ThreadSummary(BaseModel):
+    """One entry of :class:`ListThreadsResult`; a JSON-friendly ``ThreadInfo``."""
+
+    thread_id: str
+    thread_name: str | None
+    status: str
+    input_shape: str
+    parent_id: str | None
+    is_self: bool
+
+class ListThreadsResult(BaseModel):
+    """Return shape of :func:`list_threads`."""
+
+    threads: list[ThreadSummary]
+
+class ListThreadsArgs(BaseModel):
+    """Arguments of :func:`list_threads` — there are none."""
+
+class SendMessageArgs(BaseModel):
+    """Arguments of :func:`send_message`; the sole declaration of its schema."""
+
+    thread_id: str
+    message: str
+    mode: SendMessageMode
+
+async def list_threads(coordinator: Coordinator, self_thread_id: str) -> ListThreadsResult:
+    """Snapshot every thread registered with ``coordinator``.
+
+    Args:
+        coordinator: Coordinator to enumerate.
+        self_thread_id: Id of the calling thread, marked ``is_self``.
+
+    Returns:
+        One :class:`ThreadSummary` per registered thread, order
+        coordinator-defined.
+    """
+    ...
+
+async def send_message(
+    coordinator: Coordinator,
+    self_thread_id: str,
+    thread_id: str,
+    message: str,
+    mode: str = "wait",
+) -> str:
+    """Dispatch ``message`` to ``thread_id`` according to ``mode``.
+
+    Every failure is reported as an ``"error: ..."`` string rather than raised:
+    the caller is a language model, and a returned message it can act on beats
+    an exception that aborts its turn.
+
+    ``mode`` is typed as ``str``, not :data:`SendMessageMode`, and validated
+    inside the body. Adapters publish the enum in their schema, but a transport
+    that lets an unconstrained value through must still get a usable answer
+    instead of a crash.
+
+    A blocking ``"wait"`` is refused when granting it would close a cycle in the
+    graph of in-flight waits, so two peers waiting on each other cannot deadlock
+    their dispatchers. Because that graph is held here rather than per adapter, a
+    cycle spanning runtimes is caught too.
+
+    Args:
+        coordinator: Coordinator hosting both threads.
+        self_thread_id: Id of the calling thread.
+        thread_id: Id of the peer to send to.
+        message: Message body delivered as the peer's user turn.
+        mode: One of :data:`SEND_MESSAGE_MODES`.
+
+    Returns:
+        The peer's reply for ``"wait"``, an acknowledgement for the two
+        non-blocking modes, or an ``"error: ..."`` description.
+    """
+    ...

--- a/src/ai_functions/ai_thread/tools.py
+++ b/src/ai_functions/ai_thread/tools.py
@@ -6,26 +6,12 @@ The default ``config_hook`` installed on every ``AIFunction`` calls
 :func:`coordinator_tools` with the cycle's ``ctx`` and appends the
 result to ``cycle_config.tools``.
 
-Two tools are exposed:
-
-- ``list_threads()`` — return a JSON-friendly snapshot of every thread
-  registered with the calling agent's coordinator, including a
-  ``is_self`` flag marking the calling thread.
-- ``send_message(thread_id, message, mode="wait")`` — invoke a peer
-  thread via its typed ``run(message)`` entry point. The peer must have
-  ``input_shape == STR_PROMPT``. ``mode`` selects how the sender relates
-  to the peer's result:
-
-  - ``"wait"`` (default): await the peer's cycle; return its reply as
-    the tool's result. Blocks the sender's cycle on the peer's cycle.
-  - ``"fire_and_forget"``: schedule the peer's cycle as a background
-    task; return immediately. The peer's reply is discarded.
-  - ``"continue_then_receive"``: schedule the peer's cycle, return
-    immediately, and when the peer completes, enqueue a fresh cycle on
-    the sender with the peer's reply formatted as the user turn. This
-    mode requires the sender itself to have ``input_shape == STR_PROMPT``
-    — the tool returns an error otherwise, asking the agent to use
-    ``"wait"``.
+Two tools are exposed, ``list_threads()`` and
+``send_message(thread_id, message, mode="wait")``. Their semantics, wire
+descriptions, and argument schema live in
+:mod:`ai_functions.runtime.coordinator_tools_core` so that every runtime adapter
+offers the identical tool; this module is the Strands binding for them, and
+Strands derives each schema from the wrapper's signature.
 
 These tools are LLM-facing. Application code that wants the old
 inject-then-no-cycle semantics should call
@@ -34,68 +20,19 @@ inject-then-no-cycle semantics should call
 
 from __future__ import annotations
 
-import asyncio
-import json
 from collections.abc import Sequence
 
 from strands.tools.decorator import tool as _strands_tool  # pyright: ignore[reportUnknownVariableType]
 from strands.types.tools import AgentTool
 
-from ..types import InputShape, ThreadContext, ThreadId
-
-# ── Deadlock detection for blocking ``send_message(mode="wait")`` ────────────
-#
-# A blocking wait enqueues a cycle behind the peer's single serial dispatcher
-# and suspends the caller's cycle until it drains. On its own that is only
-# latency — the peer finishes what it is doing, then runs the enqueued cycle.
-# It deadlocks *only* when the peer is (directly or transitively) already
-# blocked in a wait back on the caller, so the two dispatchers can never drain
-# each other.
-#
-# We track the "waits-for" graph of in-flight blocking waits as
-# ``{coordinator_id: {waiter_id: target_id}}`` and refuse a new wait only when
-# committing to it would close a cycle. Each waiter has at most one outstanding
-# edge: while suspended in a wait its cycle cannot issue another tool call. The
-# check-and-register step runs with no ``await`` in between, so on the single
-# event loop it is atomic — of two peers waiting on each other, exactly one
-# registers first and the other observes that edge and refuses.
-#
-# Keyed by coordinator identity: peers that can actually deadlock this way
-# share one coordinator object (the in-memory coordinator the worker's executor
-# holds). Waits across separate ``CoordinatorClient`` instances are not tracked,
-# matching the existing single-coordinator scope of these tools.
-_wait_edges: dict[int, dict[str, str]] = {}
-
-
-def _would_close_wait_cycle(coord_key: int, waiter: str, target: str) -> bool:
-    """Return whether adding ``waiter -> target`` closes a wait-for cycle.
-
-    Walks the existing waits-for chain from ``target``; a cycle would form iff
-    that chain leads back to ``waiter``. The chain is acyclic by construction
-    (every edge passed this check before being added), but a ``seen`` guard
-    keeps the walk finite regardless.
-    """
-    edges = _wait_edges.get(coord_key)
-    if not edges:
-        return False
-    seen: set[str] = set()
-    cur: str | None = target
-    while cur is not None and cur not in seen:
-        if cur == waiter:
-            return True
-        seen.add(cur)
-        cur = edges.get(cur)
-    return False
-
-
-def _release_wait_edge(coord_key: int, waiter: str) -> None:
-    """Drop ``waiter``'s outstanding wait edge, pruning empty coordinator maps."""
-    edges = _wait_edges.get(coord_key)
-    if edges is None:
-        return
-    _ = edges.pop(waiter, None)
-    if not edges:
-        _ = _wait_edges.pop(coord_key, None)
+from ..runtime.coordinator_tools_core import (
+    LIST_THREADS_DESCRIPTION,
+    SEND_MESSAGE_DESCRIPTION,
+    SendMessageMode,
+)
+from ..runtime.coordinator_tools_core import list_threads as _list_threads
+from ..runtime.coordinator_tools_core import send_message as _send_message
+from ..types import ThreadContext
 
 
 def coordinator_tools(ctx: ThreadContext) -> Sequence[AgentTool]:
@@ -113,137 +50,17 @@ def coordinator_tools(ctx: ThreadContext) -> Sequence[AgentTool]:
     self_id = str(ctx.thread_id)
     coord = ctx.coordinator
 
-    @_strands_tool(
-        name="list_threads",
-        description=(
-            "List every thread registered with the current coordinator. Returns a JSON "
-            "object with a 'threads' array; each entry has 'thread_id', "
-            "'thread_name' (may be null), 'status', 'input_shape', 'parent_id' "
-            "(may be null), and 'is_self' (true for the calling thread). Use this "
-            "to discover peers before calling send_message. Only threads with "
-            "'input_shape' == 'str_prompt' can receive send_message calls."
-        ),
-    )
+    @_strands_tool(name="list_threads", description=LIST_THREADS_DESCRIPTION)
     async def list_threads() -> str:
-        infos = await coord.list_threads()
-        threads_json: list[dict[str, object]] = []
-        for info in infos:
-            threads_json.append(
-                {
-                    "thread_id": str(info.thread_id),
-                    "thread_name": info.thread_name,
-                    "status": str(info.status),
-                    "input_shape": str(info.input_shape),
-                    "parent_id": None if info.parent_id is None else str(info.parent_id),
-                    "is_self": str(info.thread_id) == self_id,
-                },
-            )
-        return json.dumps({"threads": threads_json})
+        result = await _list_threads(coord, self_id)
+        return result.model_dump_json()
 
-    @_strands_tool(
-        name="send_message",
-        description=(
-            "Send a message to a peer thread by invoking its run(message) entry "
-            "point. The peer must have input_shape='str_prompt'. 'mode' "
-            "selects how the sender relates to the peer's result:\n"
-            "  - 'wait' (default): await the peer and return its reply as the "
-            "tool result. Blocks this cycle on the peer's cycle.\n"
-            "  - 'fire_and_forget': schedule the peer's cycle in the background "
-            "and return immediately; the peer's reply is discarded.\n"
-            "  - 'continue_then_receive': schedule the peer's cycle and return "
-            "immediately; when the peer completes, a fresh cycle is scheduled on "
-            "THIS thread with the peer's reply as the user turn. Requires this "
-            "thread to have input_shape='str_prompt'. If not, the tool returns "
-            "an error and you should use mode='wait' instead.\n"
-            "Use list_threads to discover valid thread_ids."
-        ),
-    )
+    @_strands_tool(name="send_message", description=SEND_MESSAGE_DESCRIPTION)
     async def send_message(
         thread_id: str,
         message: str,
-        mode: str = "wait",
+        mode: SendMessageMode = "wait",
     ) -> str:
-        if thread_id == self_id:
-            return "error: cannot send_message to self"
-        try:
-            peer_info = await coord.get_thread_info(ThreadId(thread_id))
-        except Exception:
-            return f"error: no thread with id {thread_id}"
-        if peer_info.input_shape != InputShape.STR_PROMPT:
-            return (
-                f"error: thread {thread_id} has input_shape={peer_info.input_shape!s}; "
-                "send_message requires a str_prompt peer."
-            )
-
-        peer = coord.get_handle(ThreadId(thread_id))
-
-        if mode == "wait":
-            # A blocking wait enqueues a cycle behind the peer's single serial
-            # dispatcher and suspends this cycle until it drains. That is only a
-            # true deadlock when the peer is (directly or transitively) already
-            # waiting back on us: then neither dispatcher can drain the other.
-            # Waiting on a merely-busy peer that is *not* waiting on us is safe —
-            # it finishes its work, then runs our enqueued cycle. So we refuse
-            # only when committing to this wait would close a cycle in the
-            # waits-for graph. See ``_would_close_wait_cycle`` above.
-            coord_key = id(coord)
-            if _would_close_wait_cycle(coord_key, self_id, thread_id):
-                return (
-                    f"error: thread {thread_id} is already waiting on this thread; "
-                    "send_message(mode='wait') would deadlock. Use "
-                    "mode='fire_and_forget' or mode='continue_then_receive' instead."
-                )
-            # Register our outstanding edge before awaiting, with no intervening
-            # ``await`` — so a peer that tries to wait back on us observes it and
-            # refuses (breaking the cycle on exactly one side).
-            _wait_edges.setdefault(coord_key, {})[self_id] = thread_id
-            try:
-                result = await peer.run(message)
-            except Exception as exc:
-                return f"error: {exc}"
-            finally:
-                _release_wait_edge(coord_key, self_id)
-            return str(result)
-
-        if mode == "fire_and_forget":
-            fut = peer.run(message)
-
-            async def _swallow() -> None:
-                try:
-                    _ = await fut
-                except Exception:
-                    pass
-
-            _ = asyncio.create_task(_swallow())
-            return f"ok: dispatched to {thread_id}"
-
-        if mode == "continue_then_receive":
-            try:
-                self_info = await coord.get_thread_info(ctx.thread_id)
-            except Exception:
-                return "error: calling thread is no longer registered"
-            if self_info.input_shape != InputShape.STR_PROMPT:
-                return (
-                    "error: continue_then_receive requires this thread to "
-                    "have input_shape='str_prompt'. Use mode='wait' instead."
-                )
-            sender = coord.get_handle(ctx.thread_id)
-            fut = peer.run(message)
-
-            async def _notify_on_complete() -> None:
-                try:
-                    peer_result = await fut
-                    notification = f"[Reply from {thread_id}] {peer_result}"
-                except Exception as exc:
-                    notification = f"[Reply from {thread_id}] error: {exc}"
-                try:
-                    _ = sender.run(notification)
-                except Exception:
-                    pass
-
-            _ = asyncio.create_task(_notify_on_complete())
-            return f"ok: dispatched to {thread_id}; reply will arrive as a new user turn"
-
-        return f"error: unknown mode {mode!r}; valid modes are 'wait', 'fire_and_forget', 'continue_then_receive'"
+        return await _send_message(coord, self_id, thread_id, message, mode)
 
     return [list_threads, send_message]

--- a/src/ai_functions/claude_code/coordinator_tools.py
+++ b/src/ai_functions/claude_code/coordinator_tools.py
@@ -1,21 +1,17 @@
 """Runtime-facing tools exposed to a Claude Agent SDK session.
 
-Mirror of :mod:`ai_functions.ai_thread.tools` for the Claude Agent runtime.
+Claude Agent SDK binding for the two runtime-facing tools.
 ``coordinator_tools(ctx)`` returns a ``Sequence[SdkMcpTool]`` that can
 be packaged via :func:`runtime_mcp_server` into the
 ``McpSdkServerConfig`` consumed by ``ClaudeAgentOptions.mcp_servers``.
 
-Two tools are exposed:
-
-- ``list_threads()`` — return a JSON-friendly snapshot of every thread
-  registered with the calling agent's coordinator, including a
-  ``is_self`` flag marking the calling thread.
-- ``send_message(thread_id, message, mode="wait")`` — invoke a peer
-  thread via its typed ``run(message)`` entry point. The peer must
-  have ``input_shape == STR_PROMPT``. ``mode`` selects how the sender
-  relates to the peer's result, with the same ``"wait"`` /
-  ``"fire_and_forget"`` / ``"continue_then_receive"`` semantics as
-  the Strands-side ``send_message``.
+The tools are ``list_threads()`` and
+``send_message(thread_id, message, mode="wait")``. Their semantics, wire
+descriptions, and argument schemas live in
+:mod:`ai_functions.runtime.coordinator_tools_core`, shared with the Strands
+binding in :mod:`ai_functions.ai_thread.tools`, so an agent sees the same tool
+whichever runtime hosts it. This module adds only the SDK decorator and the MCP
+content packing.
 
 The MCP server reserves the name ``_ai_functions_runtime`` in the
 ``mcp_servers`` mapping. Users may not register their own server
@@ -25,19 +21,30 @@ time.
 
 from __future__ import annotations
 
-import asyncio
-import json
 from collections.abc import Callable, Sequence
 from typing import Any
 
 from claude_agent_sdk import McpSdkServerConfig, SdkMcpTool, create_sdk_mcp_server, tool
 
-from ..types import InputShape, ThreadContext, ThreadId
+from ..runtime.coordinator_tools_core import (
+    LIST_THREADS_DESCRIPTION,
+    LIST_THREADS_INPUT_SCHEMA,
+    SEND_MESSAGE_DESCRIPTION,
+    SEND_MESSAGE_INPUT_SCHEMA,
+)
+from ..runtime.coordinator_tools_core import list_threads as _list_threads
+from ..runtime.coordinator_tools_core import send_message as _send_message
+from ..types import ThreadContext
 
 _RUNTIME_SERVER_NAME = "_ai_functions_runtime"
 """Reserved key under which the runtime MCP server registers in
 ``ClaudeAgentOptions.mcp_servers``. Users may not register their own
 server under this name."""
+
+
+def _text_result(text: str) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]  # SDK callback contract
+    """Wrap ``text`` in the single-text-block result shape the SDK expects."""
+    return {"content": [{"type": "text", "text": text}]}
 
 
 def coordinator_tools(ctx: ThreadContext) -> Sequence[SdkMcpTool[object]]:
@@ -57,79 +64,33 @@ def _coordinator_tools_with_provider(
     returns the active cycle's ctx during a tool call.
     """
 
-    @tool(
-        "list_threads",
-        (
-            "List every thread registered with the current coordinator. "
-            "Returns a JSON object with a 'threads' array; each entry has "
-            "'thread_id', 'thread_name' (may be null), 'status', "
-            "'input_shape', 'parent_id' (may be null), and 'is_self' "
-            "(true for the calling thread). Use this to discover peers "
-            "before calling send_message. Only threads with "
-            "'input_shape' == 'str_prompt' can receive send_message calls."
-        ),
-        {},
-    )
+    @tool("list_threads", LIST_THREADS_DESCRIPTION, LIST_THREADS_INPUT_SCHEMA)
     async def list_threads(
         _args: dict[str, Any],  # pyright: ignore[reportExplicitAny]  # SDK callback contract
     ) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]  # SDK callback contract
         """Return a JSON-friendly snapshot of registered threads."""
         ctx = ctx_provider()
         if ctx is None:
-            return {"content": [{"type": "text", "text": "error: no active cycle"}]}
-        self_id = str(ctx.thread_id)
-        infos = await ctx.coordinator.list_threads()
-        threads_json: list[dict[str, object]] = []
-        for info in infos:
-            threads_json.append(
-                {
-                    "thread_id": str(info.thread_id),
-                    "thread_name": info.thread_name,
-                    "status": str(info.status),
-                    "input_shape": str(info.input_shape),
-                    "parent_id": None if info.parent_id is None else str(info.parent_id),
-                    "is_self": str(info.thread_id) == self_id,
-                },
-            )
-        return {
-            "content": [
-                {"type": "text", "text": json.dumps({"threads": threads_json})},
-            ],
-        }
+            return _text_result("error: no active cycle")
+        result = await _list_threads(ctx.coordinator, str(ctx.thread_id))
+        return _text_result(result.model_dump_json())
 
-    @tool(
-        "send_message",
-        (
-            "Send a message to a peer thread by invoking its run(message) "
-            "entry point. The peer must have input_shape='str_prompt'. "
-            "'mode' selects how the sender relates to the peer's result:\n"
-            "  - 'wait' (default): await the peer and return its reply as "
-            "the tool result. Blocks this cycle on the peer's cycle.\n"
-            "  - 'fire_and_forget': schedule the peer's cycle in the "
-            "background and return immediately; the peer's reply is "
-            "discarded.\n"
-            "  - 'continue_then_receive': schedule the peer's cycle and "
-            "return immediately; when the peer completes, a fresh cycle "
-            "is scheduled on THIS thread with the peer's reply as the "
-            "user turn. Requires this thread to have "
-            "input_shape='str_prompt'. If not, the tool returns an error "
-            "and you should use mode='wait' instead.\n"
-            "Use list_threads to discover valid thread_ids."
-        ),
-        {"thread_id": str, "message": str, "mode": str},
-    )
+    @tool("send_message", SEND_MESSAGE_DESCRIPTION, SEND_MESSAGE_INPUT_SCHEMA)
     async def send_message(
         args: dict[str, Any],  # pyright: ignore[reportExplicitAny]  # SDK callback contract
     ) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]  # SDK callback contract
         """Dispatch ``message`` to ``thread_id`` according to ``mode``."""
         ctx = ctx_provider()
         if ctx is None:
-            return {"content": [{"type": "text", "text": "error: no active cycle"}]}
-        thread_id = str(args["thread_id"])
-        message = str(args["message"])
-        mode = str(args.get("mode", "wait"))
-        text = await _dispatch(ctx, str(ctx.thread_id), thread_id, message, mode)
-        return {"content": [{"type": "text", "text": text}]}
+            return _text_result("error: no active cycle")
+        text = await _send_message(
+            ctx.coordinator,
+            str(ctx.thread_id),
+            str(args["thread_id"]),
+            str(args["message"]),
+            str(args.get("mode", "wait")),
+        )
+        return _text_result(text)
 
     return [list_threads, send_message]
 
@@ -148,79 +109,3 @@ def _runtime_mcp_server_with_provider(
         version="1.0.0",
         tools=list(_coordinator_tools_with_provider(ctx_provider)),
     )
-
-
-# ── Internals ────────────────────────────────────────────────────────
-
-
-async def _dispatch(
-    ctx: ThreadContext,
-    self_id: str,
-    thread_id: str,
-    message: str,
-    mode: str,
-) -> str:
-    """Route ``message`` to ``thread_id`` per ``mode``; return the tool's text."""
-    if thread_id == self_id:
-        return "error: cannot send_message to self"
-
-    coord = ctx.coordinator
-    try:
-        peer_info = await coord.get_thread_info(ThreadId(thread_id))
-    except Exception:
-        return f"error: no thread with id {thread_id}"
-    if peer_info.input_shape != InputShape.STR_PROMPT:
-        return (
-            f"error: thread {thread_id} has input_shape={peer_info.input_shape!s}; "
-            "send_message requires a str_prompt peer."
-        )
-
-    peer = coord.get_handle(ThreadId(thread_id))
-
-    if mode == "wait":
-        try:
-            result = await peer.run(message)
-        except Exception as exc:
-            return f"error: {exc}"
-        return str(result)
-
-    if mode == "fire_and_forget":
-        fut = peer.run(message)
-
-        async def _swallow() -> None:
-            try:
-                _ = await fut
-            except Exception:
-                pass
-
-        _ = asyncio.create_task(_swallow())
-        return f"ok: dispatched to {thread_id}"
-
-    if mode == "continue_then_receive":
-        try:
-            self_info = await coord.get_thread_info(ctx.thread_id)
-        except Exception:
-            return "error: calling thread is no longer registered"
-        if self_info.input_shape != InputShape.STR_PROMPT:
-            return (
-                "error: continue_then_receive requires this thread to "
-                "have input_shape='str_prompt'. Use mode='wait' instead."
-            )
-        sender = coord.get_handle(ctx.thread_id)
-        fut = peer.run(message)
-
-        async def _notify_on_complete() -> None:
-            try:
-                peer_result = await fut
-                notification = f"[Reply from {thread_id}] {peer_result}"
-            except Exception as exc:
-                notification = f"[Reply from {thread_id}] error: {exc}"
-            try:
-                _ = sender.run(notification)
-            except Exception:
-                pass
-
-        _ = asyncio.create_task(_notify_on_complete())
-        return f"ok: dispatched to {thread_id}; reply will arrive as a new user turn"
-
-    return f"error: unknown mode {mode!r}; valid modes are 'wait', 'fire_and_forget', 'continue_then_receive'"

--- a/src/ai_functions/runtime/coordinator_tools_core.py
+++ b/src/ai_functions/runtime/coordinator_tools_core.py
@@ -1,0 +1,344 @@
+"""Transport-agnostic bodies for the two runtime-facing coordinator tools.
+
+Every runtime adapter that exposes ``list_threads`` / ``send_message`` to an
+agent — the Strands-native path in :mod:`ai_functions.ai_thread.tools` and the
+Claude Agent SDK MCP path in :mod:`ai_functions.claude_code.coordinator_tools` —
+calls into this module. Adapters own only their transport's plumbing (decorator,
+schema handoff, result packing); the semantics, the wire-visible descriptions,
+the argument schemas, and the deadlock guard live here once so no two agents can
+be offered different versions of the same tool.
+
+The bodies take ``(coordinator, self_thread_id)`` rather than a
+:class:`~ai_functions.types.ThreadContext`, because that pair is all they need.
+An adapter with no live cycle to draw a context from can therefore still serve
+the tools.
+
+Schemas are derived, never written twice: :class:`SendMessageArgs` is the single
+declaration of ``send_message``'s arguments, and adapters either bind their
+decorator to a matching signature or hand
+:data:`SEND_MESSAGE_INPUT_SCHEMA` (``SendMessageArgs.model_json_schema()``)
+straight to their SDK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal, get_args
+
+from pydantic import BaseModel, Field
+
+from ..protocols import Coordinator
+from ..types import InputShape, ThreadId
+
+__all__ = [
+    "LIST_THREADS_DESCRIPTION",
+    "LIST_THREADS_INPUT_SCHEMA",
+    "SEND_MESSAGE_DESCRIPTION",
+    "SEND_MESSAGE_INPUT_SCHEMA",
+    "SEND_MESSAGE_MODES",
+    "ListThreadsArgs",
+    "ListThreadsResult",
+    "SendMessageArgs",
+    "SendMessageMode",
+    "ThreadSummary",
+    "list_threads",
+    "send_message",
+]
+
+
+# ── Argument and result models ──────────────────────────────────────────────
+
+SendMessageMode = Literal["wait", "fire_and_forget", "continue_then_receive"]
+"""How the sender relates to the peer's result. See :data:`SEND_MESSAGE_DESCRIPTION`."""
+
+SEND_MESSAGE_MODES: tuple[str, ...] = get_args(SendMessageMode)
+"""The legal :data:`SendMessageMode` values, for runtime validation."""
+
+
+class ThreadSummary(BaseModel):
+    """One entry of :class:`ListThreadsResult`; a JSON-friendly ``ThreadInfo``."""
+
+    thread_id: str
+    thread_name: str | None
+    status: str
+    input_shape: str
+    parent_id: str | None
+    is_self: bool
+    """True for the thread whose agent is calling the tool."""
+
+
+class ListThreadsResult(BaseModel):
+    """Return shape of :func:`list_threads`."""
+
+    threads: list[ThreadSummary]
+
+
+class ListThreadsArgs(BaseModel):
+    """Arguments of :func:`list_threads` — there are none."""
+
+
+class SendMessageArgs(BaseModel):
+    """Arguments of :func:`send_message`; the sole declaration of its schema."""
+
+    thread_id: str = Field(description="Id of the peer thread to send to.")
+    message: str = Field(description="Message body delivered as the peer's user turn.")
+    mode: SendMessageMode = Field(
+        default="wait",
+        description=(
+            "How this thread relates to the peer's result: 'wait' blocks on the "
+            "reply, 'fire_and_forget' discards it, 'continue_then_receive' "
+            "delivers it as a later user turn on this thread."
+        ),
+    )
+
+
+LIST_THREADS_DESCRIPTION = (
+    "List every thread registered with the current coordinator. Returns a JSON "
+    "object with a 'threads' array; each entry has 'thread_id', "
+    "'thread_name' (may be null), 'status', 'input_shape', 'parent_id' "
+    "(may be null), and 'is_self' (true for the calling thread). Use this "
+    "to discover peers before calling send_message. Only threads with "
+    "'input_shape' == 'str_prompt' can receive send_message calls."
+)
+
+SEND_MESSAGE_DESCRIPTION = (
+    "Send a message to a peer thread by invoking its run(message) entry "
+    "point. The peer must have input_shape='str_prompt'. 'mode' "
+    "selects how the sender relates to the peer's result:\n"
+    "  - 'wait' (default): await the peer and return its reply as the "
+    "tool result. Blocks this cycle on the peer's cycle.\n"
+    "  - 'fire_and_forget': schedule the peer's cycle in the background "
+    "and return immediately; the peer's reply is discarded.\n"
+    "  - 'continue_then_receive': schedule the peer's cycle and return "
+    "immediately; when the peer completes, a fresh cycle is scheduled on "
+    "THIS thread with the peer's reply as the user turn. Requires this "
+    "thread to have input_shape='str_prompt'. If not, the tool returns "
+    "an error and you should use mode='wait' instead.\n"
+    "Use list_threads to discover valid thread_ids."
+)
+
+
+def _tool_input_schema(model: type[BaseModel]) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]
+    """Render ``model`` as a tool input schema.
+
+    Drops the model-level ``title`` and ``description`` Pydantic derives from the
+    class name and docstring: both SDKs carry the tool's name and description
+    out of band, and the docstring is written for this file's readers rather than
+    for a model reading the wire schema. Per-property descriptions are kept.
+    """
+    schema = model.model_json_schema()
+    for key in ("title", "description"):
+        _ = schema.pop(key, None)
+    return schema
+
+
+LIST_THREADS_INPUT_SCHEMA: dict[str, Any] = _tool_input_schema(ListThreadsArgs)  # pyright: ignore[reportExplicitAny]
+"""JSON Schema for ``list_threads``, for adapters whose SDK takes one directly."""
+
+SEND_MESSAGE_INPUT_SCHEMA: dict[str, Any] = _tool_input_schema(SendMessageArgs)  # pyright: ignore[reportExplicitAny]
+"""JSON Schema for ``send_message``, for adapters whose SDK takes one directly.
+
+Derived from :class:`SendMessageArgs`, so ``mode`` reaches every runtime as an
+enum with a default rather than as a bare string.
+"""
+
+
+# ── Deadlock detection for blocking ``send_message(mode="wait")`` ────────────
+#
+# A blocking wait enqueues a cycle behind the peer's single serial dispatcher
+# and suspends the caller's cycle until it drains. On its own that is only
+# latency — the peer finishes what it is doing, then runs the enqueued cycle.
+# It deadlocks *only* when the peer is (directly or transitively) already
+# blocked in a wait back on the caller, so the two dispatchers can never drain
+# each other.
+#
+# We track the "waits-for" graph of in-flight blocking waits as
+# ``{coordinator_id: {waiter_id: target_id}}`` and refuse a new wait only when
+# committing to it would close a cycle. Each waiter has at most one outstanding
+# edge: while suspended in a wait its cycle cannot issue another tool call. The
+# check-and-register step runs with no ``await`` in between, so on the single
+# event loop it is atomic — of two peers waiting on each other, exactly one
+# registers first and the other observes that edge and refuses.
+#
+# Keyed by coordinator identity: peers that can actually deadlock this way
+# share one coordinator object (the in-memory coordinator the worker's executor
+# holds). Waits across separate ``CoordinatorClient`` instances are not tracked,
+# matching the existing single-coordinator scope of these tools. Because the
+# graph lives here rather than in one adapter, a cycle spanning runtimes — a
+# Claude thread and an AI Function waiting on each other — is caught too.
+_wait_edges: dict[int, dict[str, str]] = {}
+
+
+def _would_close_wait_cycle(coord_key: int, waiter: str, target: str) -> bool:
+    """Return whether adding ``waiter -> target`` closes a wait-for cycle.
+
+    Walks the existing waits-for chain from ``target``; a cycle would form iff
+    that chain leads back to ``waiter``. The chain is acyclic by construction
+    (every edge passed this check before being added), but a ``seen`` guard
+    keeps the walk finite regardless.
+    """
+    edges = _wait_edges.get(coord_key)
+    if not edges:
+        return False
+    seen: set[str] = set()
+    cur: str | None = target
+    while cur is not None and cur not in seen:
+        if cur == waiter:
+            return True
+        seen.add(cur)
+        cur = edges.get(cur)
+    return False
+
+
+def _release_wait_edge(coord_key: int, waiter: str) -> None:
+    """Drop ``waiter``'s outstanding wait edge, pruning empty coordinator maps."""
+    edges = _wait_edges.get(coord_key)
+    if edges is None:
+        return
+    _ = edges.pop(waiter, None)
+    if not edges:
+        _ = _wait_edges.pop(coord_key, None)
+
+
+# ── Tool bodies ─────────────────────────────────────────────────────────────
+
+
+async def list_threads(coordinator: Coordinator, self_thread_id: str) -> ListThreadsResult:
+    """Snapshot every thread registered with ``coordinator``.
+
+    Args:
+        coordinator: Coordinator to enumerate.
+        self_thread_id: Id of the calling thread, marked ``is_self``.
+
+    Returns:
+        One :class:`ThreadSummary` per registered thread, order
+        coordinator-defined.
+    """
+    infos = await coordinator.list_threads()
+    return ListThreadsResult(
+        threads=[
+            ThreadSummary(
+                thread_id=str(info.thread_id),
+                thread_name=info.thread_name,
+                status=str(info.status),
+                input_shape=str(info.input_shape),
+                parent_id=None if info.parent_id is None else str(info.parent_id),
+                is_self=str(info.thread_id) == self_thread_id,
+            )
+            for info in infos
+        ],
+    )
+
+
+async def send_message(
+    coordinator: Coordinator,
+    self_thread_id: str,
+    thread_id: str,
+    message: str,
+    mode: str = "wait",
+) -> str:
+    """Dispatch ``message`` to ``thread_id`` according to ``mode``.
+
+    Every failure is reported as an ``"error: ..."`` string rather than raised:
+    the caller is a language model, and a returned message it can act on beats
+    an exception that aborts its turn.
+
+    ``mode`` is typed as ``str``, not :data:`SendMessageMode`, and validated at
+    the bottom of this function. Adapters publish the enum in their schema, but
+    a transport that lets an unconstrained value through must still get a usable
+    answer instead of a crash.
+
+    Args:
+        coordinator: Coordinator hosting both threads.
+        self_thread_id: Id of the calling thread.
+        thread_id: Id of the peer to send to.
+        message: Message body delivered as the peer's user turn.
+        mode: One of :data:`SEND_MESSAGE_MODES`.
+
+    Returns:
+        The peer's reply for ``"wait"``, an acknowledgement for the two
+        non-blocking modes, or an ``"error: ..."`` description.
+    """
+    if thread_id == self_thread_id:
+        return "error: cannot send_message to self"
+    try:
+        peer_info = await coordinator.get_thread_info(ThreadId(thread_id))
+    except Exception:  # noqa: BLE001 - any lookup failure means "no such peer"
+        return f"error: no thread with id {thread_id}"
+    if peer_info.input_shape != InputShape.STR_PROMPT:
+        return (
+            f"error: thread {thread_id} has input_shape={peer_info.input_shape!s}; "
+            "send_message requires a str_prompt peer."
+        )
+
+    peer = coordinator.get_handle(ThreadId(thread_id))
+
+    if mode == "wait":
+        # A blocking wait enqueues a cycle behind the peer's single serial
+        # dispatcher and suspends this cycle until it drains. That is only a
+        # true deadlock when the peer is (directly or transitively) already
+        # waiting back on us: then neither dispatcher can drain the other.
+        # Waiting on a merely-busy peer that is *not* waiting on us is safe —
+        # it finishes its work, then runs our enqueued cycle. So we refuse
+        # only when committing to this wait would close a cycle in the
+        # waits-for graph. See ``_would_close_wait_cycle`` above.
+        coord_key = id(coordinator)
+        if _would_close_wait_cycle(coord_key, self_thread_id, thread_id):
+            return (
+                f"error: thread {thread_id} is already waiting on this thread; "
+                "send_message(mode='wait') would deadlock. Use "
+                "mode='fire_and_forget' or mode='continue_then_receive' instead."
+            )
+        # Register our outstanding edge before awaiting, with no intervening
+        # ``await`` — so a peer that tries to wait back on us observes it and
+        # refuses (breaking the cycle on exactly one side).
+        _wait_edges.setdefault(coord_key, {})[self_thread_id] = thread_id
+        try:
+            result = await peer.run(message)
+        except Exception as exc:  # noqa: BLE001 - surfaced to the model as text
+            return f"error: {exc}"
+        finally:
+            _release_wait_edge(coord_key, self_thread_id)
+        return str(result)
+
+    if mode == "fire_and_forget":
+        fut = peer.run(message)
+
+        async def _swallow() -> None:
+            try:
+                _ = await fut
+            except Exception:  # noqa: BLE001 - the reply is discarded by design
+                pass
+
+        _ = asyncio.create_task(_swallow())
+        return f"ok: dispatched to {thread_id}"
+
+    if mode == "continue_then_receive":
+        self_id = ThreadId(self_thread_id)
+        try:
+            self_info = await coordinator.get_thread_info(self_id)
+        except Exception:  # noqa: BLE001 - caller vanished mid-cycle
+            return "error: calling thread is no longer registered"
+        if self_info.input_shape != InputShape.STR_PROMPT:
+            return (
+                "error: continue_then_receive requires this thread to "
+                "have input_shape='str_prompt'. Use mode='wait' instead."
+            )
+        sender = coordinator.get_handle(self_id)
+        fut = peer.run(message)
+
+        async def _notify_on_complete() -> None:
+            try:
+                peer_result = await fut
+                notification = f"[Reply from {thread_id}] {peer_result}"
+            except Exception as exc:  # noqa: BLE001 - reported to the sender as text
+                notification = f"[Reply from {thread_id}] error: {exc}"
+            try:
+                _ = sender.run(notification)
+            except Exception:  # noqa: BLE001 - sender may be gone; nothing to do
+                pass
+
+        _ = asyncio.create_task(_notify_on_complete())
+        return f"ok: dispatched to {thread_id}; reply will arrive as a new user turn"
+
+    return f"error: unknown mode {mode!r}; valid modes are 'wait', 'fire_and_forget', 'continue_then_receive'"

--- a/src/ai_functions/runtime/coordinator_tools_core.py
+++ b/src/ai_functions/runtime/coordinator_tools_core.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Literal, get_args
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..protocols import Coordinator
 from ..types import InputShape, ThreadId
@@ -36,7 +36,6 @@ __all__ = [
     "SEND_MESSAGE_DESCRIPTION",
     "SEND_MESSAGE_INPUT_SCHEMA",
     "SEND_MESSAGE_MODES",
-    "ListThreadsArgs",
     "ListThreadsResult",
     "SendMessageArgs",
     "SendMessageMode",
@@ -56,29 +55,55 @@ SEND_MESSAGE_MODES: tuple[str, ...] = get_args(SendMessageMode)
 
 
 class ThreadSummary(BaseModel):
-    """One entry of :class:`ListThreadsResult`; a JSON-friendly ``ThreadInfo``."""
+    """One entry of :class:`ListThreadsResult`; an agent-facing ``ThreadInfo``.
+
+    Every field is widened to ``str`` because this crosses a tool boundary to a
+    language model: :class:`~ai_functions.types.ThreadInfo` carries ``ThreadId``
+    newtypes and ``StrEnum`` members, and a model reading the tool result has no
+    use for that distinction. Frozen, like ``ThreadInfo``, so it round-trips over
+    the wire via ``model_dump_json`` / ``model_validate_json``.
+    """
+
+    model_config = ConfigDict(frozen=True)
 
     thread_id: str
+    """Runtime-assigned id of this thread; the value to pass to ``send_message``."""
+
     thread_name: str | None
+    """Human-readable name supplied at spawn time (may be ``None``)."""
+
     status: str
+    """Lifecycle status of this thread at snapshot time."""
+
     input_shape: str
+    """Coarse shape of the thread's ``execute`` input signature. Only
+    ``"str_prompt"`` threads can receive ``send_message``."""
+
     parent_id: str | None
+    """Id of the parent thread, if this thread was spawned with one."""
+
     is_self: bool
     """True for the thread whose agent is calling the tool."""
 
 
 class ListThreadsResult(BaseModel):
-    """Return shape of :func:`list_threads`."""
+    """Return shape of :func:`list_threads`. Frozen; serialises via ``model_dump_json``."""
+
+    model_config = ConfigDict(frozen=True)
 
     threads: list[ThreadSummary]
-
-
-class ListThreadsArgs(BaseModel):
-    """Arguments of :func:`list_threads` — there are none."""
+    """One entry per thread registered with the coordinator, order coordinator-defined."""
 
 
 class SendMessageArgs(BaseModel):
-    """Arguments of :func:`send_message`; the sole declaration of its schema."""
+    """Arguments of :func:`send_message`; the sole declaration of its schema.
+
+    Exists to be rendered as a schema rather than to be instantiated: adapters
+    whose SDK wants a JSON Schema get :data:`SEND_MESSAGE_INPUT_SCHEMA` from it,
+    and adapters that infer from a signature declare the same three parameters.
+    """
+
+    model_config = ConfigDict(frozen=True)
 
     thread_id: str = Field(description="Id of the peer thread to send to.")
     message: str = Field(description="Message body delivered as the peer's user turn.")
@@ -132,8 +157,12 @@ def _tool_input_schema(model: type[BaseModel]) -> dict[str, Any]:  # pyright: ig
     return schema
 
 
-LIST_THREADS_INPUT_SCHEMA: dict[str, Any] = _tool_input_schema(ListThreadsArgs)  # pyright: ignore[reportExplicitAny]
-"""JSON Schema for ``list_threads``, for adapters whose SDK takes one directly."""
+LIST_THREADS_INPUT_SCHEMA: dict[str, Any] = {"type": "object", "properties": {}}  # pyright: ignore[reportExplicitAny]
+"""JSON Schema for ``list_threads``, for adapters whose SDK takes one directly.
+
+Written out rather than derived from a model: the tool takes no arguments, so
+there is nothing for a second declaration to drift from.
+"""
 
 SEND_MESSAGE_INPUT_SCHEMA: dict[str, Any] = _tool_input_schema(SendMessageArgs)  # pyright: ignore[reportExplicitAny]
 """JSON Schema for ``send_message``, for adapters whose SDK takes one directly.

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -37,6 +37,11 @@ ai_functions.memory.procedural.Procedural.*
 # declares it identically, but stubtest cannot represent a TypeAliasType as a Union and flags it.
 ai_functions.types.graph.Traceable
 
+# ``SendMessageMode = Literal["wait", "fire_and_forget", "continue_then_receive"]``. The stub
+# declares the identical Literal, but stubtest resolves the runtime alias to a callable
+# special form and reports it as "not a Union".
+ai_functions.runtime.coordinator_tools_core.SendMessageMode
+
 # NewType creates functions at runtime; stubs declare them as classes (TypeInfo)
 ai_functions.types.ids.EventId
 ai_functions.types.ids.MessageId

--- a/tests/test_coordinator_tools_core.py
+++ b/tests/test_coordinator_tools_core.py
@@ -1,0 +1,201 @@
+"""The shared coordinator-tool core, and the schema parity it exists to enforce.
+
+``list_threads`` / ``send_message`` are published to agents by more than one
+runtime adapter. These tests pin the two properties that made a shared core
+necessary: every adapter offers the same argument schema and the same
+descriptions, and the body's defensive validation still answers a caller that
+reaches it with an unvalidated argument.
+"""
+
+import importlib
+
+import pytest
+from strands.tools.decorator import tool as strands_tool
+
+from ai_functions.runtime.coordinator_tools_core import (
+    LIST_THREADS_DESCRIPTION,
+    SEND_MESSAGE_DESCRIPTION,
+    SEND_MESSAGE_INPUT_SCHEMA,
+    SEND_MESSAGE_MODES,
+    ListThreadsResult,
+    SendMessageArgs,
+    SendMessageMode,
+    ThreadSummary,
+    send_message,
+)
+
+# NOTE: no ``from __future__ import annotations`` in this module. Strands resolves
+# the wrapper's annotations to derive the tool schema, so ``SendMessageMode`` has
+# to be a real type at decoration time rather than a deferred string.
+
+
+@strands_tool(name="send_message", description=SEND_MESSAGE_DESCRIPTION)
+async def _strands_send_message(
+    thread_id: str,
+    message: str,
+    mode: SendMessageMode = "wait",
+) -> str:
+    """Stand-in with the same signature the Strands binding uses."""
+    return ""
+
+
+def _strands_send_message_schema() -> dict[str, object]:
+    """Return the input schema Strands derives from the binding's signature."""
+    schema = _strands_send_message.tool_spec["inputSchema"]
+    return schema["json"] if "json" in schema else schema
+
+
+def _claude_send_message_schema() -> dict[str, object]:
+    """Build the Claude SDK binding's ``send_message`` and return its input schema."""
+    claude_sdk = pytest.importorskip("claude_agent_sdk")
+
+    @claude_sdk.tool("send_message", SEND_MESSAGE_DESCRIPTION, SEND_MESSAGE_INPUT_SCHEMA)
+    async def _send_message(args: dict[str, object]) -> dict[str, object]:
+        return {}
+
+    return _send_message.input_schema
+
+
+def test_send_message_mode_is_an_enum_with_a_default() -> None:
+    """``mode`` is constrained to the legal values and is not required."""
+    props = SEND_MESSAGE_INPUT_SCHEMA["properties"]
+    assert props["mode"]["enum"] == list(SEND_MESSAGE_MODES)
+    assert props["mode"]["default"] == "wait"
+    # Only the two genuinely required arguments are required.
+    assert SEND_MESSAGE_INPUT_SCHEMA["required"] == ["thread_id", "message"]
+
+
+def test_send_message_schema_is_identical_across_adapters() -> None:
+    """Both bindings publish the same argument constraints.
+
+    The Strands binding derives its schema from the wrapper signature and the
+    Claude binding hands ``SEND_MESSAGE_INPUT_SCHEMA`` to its SDK. Different
+    derivations, one declaration — so they must agree on the parts an agent can
+    observe.
+    """
+    strands = _strands_send_message_schema()
+    claude = _claude_send_message_schema()
+
+    strands_props = strands["properties"]
+    claude_props = claude["properties"]
+
+    assert set(strands_props) == set(claude_props) == {"thread_id", "message", "mode"}
+    assert strands["required"] == claude["required"] == ["thread_id", "message"]
+    for name in ("thread_id", "message", "mode"):
+        assert strands_props[name]["type"] == claude_props[name]["type"]
+    assert strands_props["mode"]["enum"] == claude_props["mode"]["enum"] == list(SEND_MESSAGE_MODES)
+    assert strands_props["mode"]["default"] == claude_props["mode"]["default"] == "wait"
+
+
+def test_tool_descriptions_are_shared_constants() -> None:
+    """Descriptions come from the core, so no adapter can describe a tool its own way."""
+    pytest.importorskip("claude_agent_sdk")
+
+    # import_module, not ``from ai_functions.claude_code import coordinator_tools``:
+    # the package re-exports a *function* of that name, which would shadow the module.
+    strands_tools = importlib.import_module("ai_functions.ai_thread.tools")
+    claude_tools = importlib.import_module("ai_functions.claude_code.coordinator_tools")
+
+    assert strands_tools.LIST_THREADS_DESCRIPTION is LIST_THREADS_DESCRIPTION
+    assert strands_tools.SEND_MESSAGE_DESCRIPTION is SEND_MESSAGE_DESCRIPTION
+    assert claude_tools.LIST_THREADS_DESCRIPTION is LIST_THREADS_DESCRIPTION
+    assert claude_tools.SEND_MESSAGE_DESCRIPTION is SEND_MESSAGE_DESCRIPTION
+
+
+def test_every_adapter_dispatches_through_the_guarded_body() -> None:
+    """Both adapters call the core bodies, so both inherit the deadlock guard.
+
+    ``send_message(mode="wait")`` refuses a wait that would close a cycle in the
+    graph of in-flight waits. That graph lives in the core and is consulted by the
+    core body, so an adapter can only get the protection by calling it — and only
+    one shared graph means a cycle spanning two runtimes is caught as well.
+    """
+    pytest.importorskip("claude_agent_sdk")
+
+    strands_tools = importlib.import_module("ai_functions.ai_thread.tools")
+    claude_tools = importlib.import_module("ai_functions.claude_code.coordinator_tools")
+    core = importlib.import_module("ai_functions.runtime.coordinator_tools_core")
+
+    for adapter in (strands_tools, claude_tools):
+        assert adapter._send_message is core.send_message
+        assert adapter._list_threads is core.list_threads
+    # The waits-for graph has exactly one home.
+    assert not hasattr(strands_tools, "_wait_edges")
+    assert not hasattr(claude_tools, "_wait_edges")
+    assert hasattr(core, "_wait_edges")
+
+
+async def test_send_message_to_self_is_refused_before_any_lookup() -> None:
+    """A self-send is rejected without touching the coordinator."""
+    result = await send_message(
+        coordinator=None,  # pyright: ignore[reportArgumentType]  # never reached
+        self_thread_id="t-self",
+        thread_id="t-self",
+        message="hi",
+        mode="wait",
+    )
+    assert result == "error: cannot send_message to self"
+
+
+async def test_send_message_unknown_mode_names_the_legal_modes() -> None:
+    """The body validates ``mode`` even when no schema layer did.
+
+    Both shipped adapters validate against the schema before dispatch, so this
+    guard is unreachable through them. It is the safety net for a transport that
+    does not validate, and it must answer with text a model can act on rather
+    than raise.
+    """
+
+    from ai_functions.types import InputShape
+
+    class _Info:
+        input_shape = InputShape.STR_PROMPT
+
+    class _Handle:
+        def run(self, message: str) -> object:
+            raise AssertionError("an unknown mode must not run a cycle on the peer")
+
+    class _StubCoordinator:
+        """Minimal coordinator: resolves one str_prompt peer, hands back a stub handle."""
+
+        async def get_thread_info(self, thread_id: object) -> object:
+            return _Info()
+
+        def get_handle(self, thread_id: object) -> object:
+            return _Handle()
+
+    result = await send_message(
+        coordinator=_StubCoordinator(),  # pyright: ignore[reportArgumentType]  # structural stub
+        self_thread_id="t-self",
+        thread_id="t-peer",
+        message="hi",
+        mode="async",
+    )
+    assert result.startswith("error: unknown mode")
+    for mode in SEND_MESSAGE_MODES:
+        assert mode in result
+
+
+def test_thread_summary_round_trips_as_json() -> None:
+    """``list_threads`` results serialise to the documented wire shape."""
+    result = ListThreadsResult(
+        threads=[
+            ThreadSummary(
+                thread_id="t-1",
+                thread_name="alice",
+                status="idle",
+                input_shape="str_prompt",
+                parent_id=None,
+                is_self=True,
+            ),
+        ],
+    )
+    payload = ListThreadsResult.model_validate_json(result.model_dump_json())
+    assert payload.threads[0].thread_name == "alice"
+    assert payload.threads[0].is_self is True
+    assert payload.threads[0].parent_id is None
+
+
+def test_send_message_args_defaults_to_wait() -> None:
+    """Omitting ``mode`` yields the documented default."""
+    assert SendMessageArgs(thread_id="t-1", message="hi").mode == "wait"

--- a/tests/test_coordinator_tools_core.py
+++ b/tests/test_coordinator_tools_core.py
@@ -10,6 +10,7 @@ reaches it with an unvalidated argument.
 import importlib
 
 import pytest
+from pydantic import ValidationError
 from strands.tools.decorator import tool as strands_tool
 
 from ai_functions.runtime.coordinator_tools_core import (
@@ -174,6 +175,22 @@ async def test_send_message_unknown_mode_names_the_legal_modes() -> None:
     assert result.startswith("error: unknown mode")
     for mode in SEND_MESSAGE_MODES:
         assert mode in result
+
+
+def test_thread_summary_is_frozen_like_thread_info() -> None:
+    """The result models are immutable snapshots, matching ``ThreadInfo``."""
+    summary = ThreadSummary(
+        thread_id="t-1",
+        thread_name="alice",
+        status="idle",
+        input_shape="str_prompt",
+        parent_id=None,
+        is_self=True,
+    )
+    with pytest.raises(ValidationError):
+        summary.thread_name = "renamed"  # pyright: ignore[reportAttributeAccessIssue]
+    with pytest.raises(ValidationError):
+        ListThreadsResult(threads=[summary]).threads = []  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def test_thread_summary_round_trips_as_json() -> None:

--- a/tests/test_runtime_tools.py
+++ b/tests/test_runtime_tools.py
@@ -400,7 +400,13 @@ async def test_send_message_to_self_returns_error() -> None:
 
 
 async def test_send_message_unknown_mode_returns_error() -> None:
-    """An unrecognised mode returns an error ack without invoking the peer."""
+    """An unrecognised mode returns an error ack without invoking the peer.
+
+    ``mode`` is an enum in the tool schema, so the rejection comes from the
+    transport's schema validation and names the legal values. The body's own
+    guard still exists for callers that reach it unvalidated; that path is
+    covered directly in ``test_coordinator_tools_core.py``.
+    """
     async with RuntimeHarness() as h:
         bob = await h.spawn(
             _chat.replace(model=ScriptedModel([Turn(text="never runs")])),
@@ -424,8 +430,10 @@ async def test_send_message_unknown_mode_returns_error() -> None:
         await alice.run("bad mode")
         tool_results = [e for e in await h.events(alice.id) if e.kind == EventKind.TOOL_RESULT]
         ack = _tool_result_text(tool_results[0])
-        assert ack.startswith("error:")
-        assert "unknown mode" in ack
+        assert "error" in ack.lower(), f"expected an error ack, got: {ack!r}"
+        # The rejection tells the agent which values are legal.
+        for mode in ("wait", "fire_and_forget", "continue_then_receive"):
+            assert mode in ack, f"expected {mode!r} named in the rejection: {ack!r}"
         # Bob's cycle must not have been triggered.
         bob_completes = [e for e in await h.events(bob.id) if e.kind == EventKind.COMPLETED]
         assert len(bob_completes) == 0


### PR DESCRIPTION
The two runtime-facing tools were implemented twice — once as Strands tools in `ai_thread/tools.py`, once as SDK MCP tools in `claude_code/coordinator_tools.py` — and the copies had diverged. This moves the semantics, descriptions, argument schema, and deadlock guard into `runtime/coordinator_tools_core.py` and reduces both call sites to transport bindings over it (−223 and −189 lines).

Pure refactor of behaviour, with three exceptions called out below. `tests/test_runtime_tools.py` (431 lines covering all three `send_message` modes, self-send, mutual-wait refusal, busy-peer queueing) is the safety net and passes.

## Three defects the duplication was hiding

**1. The Claude bridge had no deadlock detection.** The Strands copy refuses a `send_message(mode="wait")` that would close a cycle in the graph of in-flight waits; the Claude copy omitted that machinery entirely, so a Claude thread and a peer waiting on each other hung both dispatchers with no error. The waits-for graph now lives in the core, which additionally means a cycle *spanning* runtimes is caught rather than only a Strands-to-Strands one.

**2. `mode` had two contracts.** It was required in the Claude bridge's hand-written schema (`{"thread_id": str, "message": str, "mode": str}`) and optional with a `"wait"` default in the Strands signature — the same tool, two shapes.

**3. Neither copy constrained `mode` to its three legal values.** An illegal mode was caught in the body and returned as an error string. It is now an enum in the schema, derived from `SendMessageArgs`.

## Behaviour change worth reviewing

Because `mode` is now an enum, **an invalid mode is rejected by schema validation before dispatch** instead of by the body. Both transports validate — Strands via pydantic, and MCP's lowlevel server calls `jsonschema.validate` against `inputSchema` with `validate_input=True` by default — so the rejection is consistent across runtimes and now names the legal values, which is better for the model than our previous generic string.

`test_send_message_unknown_mode_returns_error` asserted the old mechanism and was updated to assert the new one. **The body's guard is deliberately kept** as the safety net for a transport that does not validate; that path is covered directly in `test_coordinator_tools_core.py::test_send_message_unknown_mode_names_the_legal_modes`. Please don't read the enum as making the guard dead code.

## Schemas are derived, not written per adapter

`SendMessageArgs` is the single declaration. Strands infers its schema from the wrapper signature; the Claude SDK takes `SEND_MESSAGE_INPUT_SCHEMA` (`model_json_schema()`) directly. Verified empirically that `claude_agent_sdk.tool` round-trips that schema verbatim and that Strands derives an identical enum from the `Literal`, and `test_send_message_schema_is_identical_across_adapters` asserts the two agree on properties, types, enum, default, and required — so this specific drift cannot recur silently.

## Verification

- `hatch run test` — 408 passed, 2 skipped
- `hatch run lint` — clean
- `hatch run check-spec` (stubtest) — no issues in 76 modules
- `pyright` on the three changed source files — 0 errors
- `ruff format --check` clean on all 5 touched files

One stubtest allowlist entry was needed: `SendMessageMode` is a `Literal` alias that stubtest resolves to a callable special form and reports as "not a Union", the same way the existing `types.policy.Policy` and `types.graph.Traceable` entries do.

## Notes for reviewers

- New spec stub `spec/ai_functions/runtime/coordinator_tools_core.pyi`; the two existing stubs' module docstrings were trimmed to point at the core rather than restate the mode semantics.
- `ruff format --check` also flags 3 files this PR does not touch (`experimental/economics/*`, `tests/test_trace_dataflow.py`). Pre-existing drift, left for a separate cleanup so this diff stays focused; the `lint` task CI runs passes.
- This is groundwork for exposing the same two tools over a third transport (a stateless in-process HTTP MCP server, so non-Claude runtimes can reach the coordinator). Nothing here depends on that landing.
