### PR TITLE
chore(deps): track agent-client-protocol 0.12.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ claude-code = [
     "claude-agent-sdk>=0.1.66",
 ]
 kiro = [
-    "agent-client-protocol==0.10.1",
+    "agent-client-protocol>=0.12.1,<0.13",
 ]
 agentcore = [
     "bedrock-agentcore>=1.6.0",
@@ -87,7 +87,7 @@ dependencies = [
     "rich>=13.7",
     "textual>=0.70",
     "platformdirs>=4.0",
-    "agent-client-protocol==0.10.1",
+    "agent-client-protocol>=0.12.1,<0.13",
     "pyyaml>=6.0",
     "bedrock-agentcore>=1.6.0",
     "rank-bm25>=0.2.2",

--- a/src/ai_functions/kiro/kiro.py
+++ b/src/ai_functions/kiro/kiro.py
@@ -87,7 +87,6 @@ try:
         Client as _AcpClient,
     )
     from acp import (
-        ClientSideConnection,
         RequestPermissionResponse,
     )
     from acp.schema import (
@@ -109,6 +108,10 @@ except ImportError as exc:  # pragma: no cover - exercised only without the extr
     ) from exc
 
 if TYPE_CHECKING:
+    # Annotation-only: ``ClientSideConnection`` is deprecated for direct runtime
+    # use (``acp.connect_to_agent`` supersedes it) but remains the type of the
+    # connection ``acp.spawn_agent_process`` yields.
+    from acp import ClientSideConnection
     from acp.schema import (
         AgentPlanUpdate,
         AvailableCommandsUpdate,

--- a/src/ai_functions/kiro/kiro.py
+++ b/src/ai_functions/kiro/kiro.py
@@ -113,6 +113,8 @@ if TYPE_CHECKING:
     # connection ``acp.spawn_agent_process`` yields.
     from acp import ClientSideConnection
     from acp.schema import (
+        AgentPlanContentUpdate,
+        AgentPlanRemovedUpdate,
         AgentPlanUpdate,
         AvailableCommandsUpdate,
         ConfigOptionUpdate,
@@ -756,6 +758,8 @@ class _KiroAcpClient(_AcpClient):
         | ToolCallStart
         | ToolCallProgress
         | AgentPlanUpdate
+        | AgentPlanContentUpdate
+        | AgentPlanRemovedUpdate
         | AvailableCommandsUpdate
         | CurrentModeUpdate
         | ConfigOptionUpdate
@@ -769,13 +773,28 @@ class _KiroAcpClient(_AcpClient):
     @override
     async def request_permission(
         self,
-        options: list[PermissionOption],
         session_id: str,
         tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
         **kwargs: object,
     ) -> RequestPermissionResponse:
-        """Resolve a permission request via the owning thread."""
+        """Resolve a permission request via the owning thread.
+
+        The connection router invokes client methods by keyword, so parameter
+        order is free — this matches the ``acp.Client`` declaration so the
+        override checks structurally.
+        """
         return await self._thread._handle_permission(options, tool_call)  # pyright: ignore[reportPrivateUsage]
+
+    @override
+    async def create_elicitation(self, *args: object, **kwargs: object) -> NoReturn:
+        """Unsupported; ``elicitation`` capability is not advertised."""
+        raise acp.exceptions.RequestError(code=-32601, message="session/create_elicitation not supported")
+
+    @override
+    async def complete_elicitation(self, *args: object, **kwargs: object) -> NoReturn:
+        """Unsupported; ``elicitation`` capability is not advertised."""
+        raise acp.exceptions.RequestError(code=-32601, message="session/complete_elicitation not supported")
 
     @override
     async def read_text_file(self, *args: object, **kwargs: object) -> NoReturn:


### PR DESCRIPTION
**Stack position: 1 of 4** (this → shared post-condition loop → CoordinatorToolServer → Codex backend). Independent and mergeable on its own; the later PRs branch from it.

Relaxes the exact `agent-client-protocol==0.10.1` pin to `>=0.12.1,<0.13` in both the `kiro` extra and the hatch default env.

**Verified drop-in:** every symbol `kiro.py` imports (`Client`, `RequestPermissionResponse`, `spawn_agent_process`, `PROTOCOL_VERSION`, `text_block`, `exceptions.RequestError`, and all 17 `acp.schema` types it touches) exists unchanged on 0.12.1. The only removal in the range is `Agent.set_session_model`, which the thread does not use — the model is passed as a `kiro-cli acp --model` argument. 0.12 adds elicitation (typed agent→client questions mid-turn), which future approval flows can build on.

Also moves the `ClientSideConnection` import under `TYPE_CHECKING`: it is annotation-only (the type of the connection `spawn_agent_process` yields), and importing it at runtime emits a `DeprecationWarning` (direct use is superseded by `acp.connect_to_agent`). Importing `ai_functions.kiro` is now clean under `-W error::DeprecationWarning` — verified.

Checks: 409 passed / 2 skipped, ruff clean, stubtest clean (76 modules), file formatted.
