### PR TITLE
refactor(threads): share the post-condition retry loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ claude-code = [
     "claude-agent-sdk>=0.1.66",
 ]
 kiro = [
-    "agent-client-protocol==0.10.1",
+    "agent-client-protocol>=0.12.1,<0.13",
 ]
 agentcore = [
     "bedrock-agentcore>=1.6.0",
@@ -87,7 +87,7 @@ dependencies = [
     "rich>=13.7",
     "textual>=0.70",
     "platformdirs>=4.0",
-    "agent-client-protocol==0.10.1",
+    "agent-client-protocol>=0.12.1,<0.13",
     "pyyaml>=6.0",
     "bedrock-agentcore>=1.6.0",
     "rank-bm25>=0.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,9 @@ network = [
     "cloudpickle>=3.0.0",
 ]
 claude-code = [
-    "claude-agent-sdk>=0.1.66",
+    # 0.2.137 first exports ``ConversationResetMessage``, which the thread maps
+    # to a CustomEvent; earlier releases cannot satisfy the import.
+    "claude-agent-sdk>=0.2.137",
 ]
 kiro = [
     "agent-client-protocol>=0.12.1,<0.13",
@@ -82,7 +84,7 @@ dependencies = [
     "mypy>=1.20.0",
     "websockets>=12.0",
     "cloudpickle>=3.0.0",
-    "claude-agent-sdk>=0.1.66",
+    "claude-agent-sdk>=0.2.137",
     "typer>=0.12",
     "rich>=13.7",
     "textual>=0.70",

--- a/spec/ai_functions/ai_thread/postcondition.pyi
+++ b/spec/ai_functions/ai_thread/postcondition.pyi
@@ -1,10 +1,23 @@
-"""Post-condition validator types."""
+"""Post-condition validator types and the shared retry loop over them.
+
+:class:`PostConditionResult` / :data:`PostCondition` define the validator
+contract. :func:`run_post_condition_loop` is the turn-level retry loop shared
+by the foreign-runtime threads (``ClaudeAgentThread``, ``KiroAgentThread``):
+each drives a session that owns its own conversation history, so the loop
+never replays the original prompt — retries ride the failure feedback as the
+next user turn. ``AIThread`` keeps its own loop because it owns its history
+and offers bound keyword arguments to condition callables; these threads take
+a single string prompt, so there are none to offer.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Awaitable
 from typing import Callable
 
 from pydantic import BaseModel, Field
+
+from ..types import ThreadContext
 
 
 class PostConditionResult(BaseModel):
@@ -44,3 +57,73 @@ Return values:
 - Raising an exception — treated as a failed condition whose message is
   the exception text.
 """
+
+async def evaluate_post_conditions(
+    result: str,
+    post_conditions: tuple[PostCondition, ...],
+) -> list[str]:
+    """Evaluate every post-condition against ``result`` in parallel.
+
+    A condition returning ``None``/``passed`` passes; ``passed=False``
+    contributes its message; a raised exception is treated as failure with
+    the exception text. Callers here take a single string prompt, so there
+    are no bound keyword arguments to offer condition callables.
+
+    Args:
+        result: The candidate result string for the turn.
+        post_conditions: Validators to run.
+
+    Returns:
+        Failure messages; empty when all conditions pass.
+    """
+    ...
+
+async def run_post_condition_loop(
+    ctx: ThreadContext,
+    prompt: str,
+    *,
+    thread_name: str,
+    post_conditions: tuple[PostCondition, ...],
+    max_attempts: int,
+    inject_buffer: list[str],
+    send_turn: Callable[[str], Awaitable[str]],
+) -> str:
+    """Run turns through ``send_turn`` until ``post_conditions`` pass.
+
+    The shared cycle body for threads whose backing session owns its own
+    conversation history. Each attempt drains ``inject_buffer``, emitting one
+    ``MESSAGE_USER`` event per entry, and prepends the drained entries to the
+    outgoing turn. On the first attempt the buffer holds any caller-supplied
+    side-channel messages and ``prompt`` is appended (with its own
+    ``MESSAGE_USER`` event); on retries the buffer holds the post-condition
+    failure feedback, and the original ``prompt`` is NOT re-sent — the session
+    owns the history, so retries ride the feedback turn.
+
+    With empty ``post_conditions`` the loop short-circuits after one turn, so
+    the default behaviour is a single query regardless of ``max_attempts``.
+
+    Args:
+        ctx: The current cycle's context; used only to emit events.
+        prompt: User prompt for the first attempt's turn.
+        thread_name: Name used in feedback messages and error attribution.
+        post_conditions: Validators run against each turn's result.
+        max_attempts: Maximum turns to satisfy ``post_conditions``; treated
+            as at least 1. Ignored when ``post_conditions`` is empty.
+        inject_buffer: The thread's live side-channel buffer. Drained here;
+            failure feedback is appended to it between attempts.
+        send_turn: Sends one combined user turn to the backing session and
+            returns its result text.
+
+    Returns:
+        The first turn result that satisfies ``post_conditions`` (or the
+        sole turn's result when there are none).
+
+    Emits:
+        MESSAGE_USER — one per drained inject-buffer entry, plus one for
+        ``prompt`` on the first attempt.
+
+    Raises:
+        AIFunctionError: ``post_conditions`` were not satisfied within
+            ``max_attempts`` attempts.
+    """
+    ...

--- a/src/ai_functions/ai_thread/postcondition.py
+++ b/src/ai_functions/ai_thread/postcondition.py
@@ -1,10 +1,24 @@
-"""Post-condition validator types."""
+"""Post-condition validator types and the shared retry loop over them.
+
+:class:`PostConditionResult` / :data:`PostCondition` define the validator
+contract. :func:`run_post_condition_loop` is the turn-level retry loop shared
+by the foreign-runtime threads (``ClaudeAgentThread``, ``KiroAgentThread``):
+each drives a session that owns its own conversation history, so the loop
+never replays the original prompt — retries ride the failure feedback as the
+next user turn. ``AIThread`` keeps its own loop because it owns its history
+and offers bound keyword arguments to condition callables; these threads take
+a single string prompt, so there are none to offer.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
+from collections.abc import Awaitable, Callable
 
 from pydantic import BaseModel, Field
+
+from ..types import MessageUserEvent, ThreadContext
+from .errors import AIFunctionError
 
 
 class PostConditionResult(BaseModel):
@@ -45,3 +59,121 @@ Return values:
 - Raising an exception — treated as a failed condition whose message is
   the exception text.
 """
+
+
+async def evaluate_post_conditions(
+    result: str,
+    post_conditions: tuple[PostCondition, ...],
+) -> list[str]:
+    """Evaluate every post-condition against ``result`` in parallel.
+
+    A condition returning ``None``/``passed`` passes; ``passed=False``
+    contributes its message; a raised exception is treated as failure with
+    the exception text. Callers here take a single string prompt, so there
+    are no bound keyword arguments to offer condition callables.
+
+    Args:
+        result: The candidate result string for the turn.
+        post_conditions: Validators to run.
+
+    Returns:
+        Failure messages; empty when all conditions pass.
+    """
+
+    async def _run_one(cond: PostCondition) -> str | None:
+        try:
+            cond_result = cond(result)
+            if asyncio.iscoroutine(cond_result):
+                cond_result = await cond_result
+        except Exception as exc:  # noqa: BLE001 - any failure is a failed condition
+            return str(exc)
+        if cond_result is None or cond_result.passed:
+            return None
+        return cond_result.message
+
+    outcomes = await asyncio.gather(*(_run_one(c) for c in post_conditions))
+    return [msg for msg in outcomes if msg is not None]
+
+
+async def run_post_condition_loop(
+    ctx: ThreadContext,
+    prompt: str,
+    *,
+    thread_name: str,
+    post_conditions: tuple[PostCondition, ...],
+    max_attempts: int,
+    inject_buffer: list[str],
+    send_turn: Callable[[str], Awaitable[str]],
+) -> str:
+    """Run turns through ``send_turn`` until ``post_conditions`` pass.
+
+    The shared cycle body for threads whose backing session owns its own
+    conversation history. Each attempt drains ``inject_buffer``, emitting one
+    ``MESSAGE_USER`` event per entry, and prepends the drained entries to the
+    outgoing turn. On the first attempt the buffer holds any caller-supplied
+    side-channel messages and ``prompt`` is appended (with its own
+    ``MESSAGE_USER`` event); on retries the buffer holds the post-condition
+    failure feedback appended below, and the original ``prompt`` is NOT
+    re-sent — the session owns the history, so retries ride the feedback turn.
+
+    With empty ``post_conditions`` the loop short-circuits after one turn, so
+    the default behaviour is a single query regardless of ``max_attempts``.
+
+    Args:
+        ctx: The current cycle's context; used only to emit events.
+        prompt: User prompt for the first attempt's turn.
+        thread_name: Name used in feedback messages and error attribution.
+        post_conditions: Validators run against each turn's result.
+        max_attempts: Maximum turns to satisfy ``post_conditions``; treated
+            as at least 1. Ignored when ``post_conditions`` is empty.
+        inject_buffer: The thread's live side-channel buffer. Drained here;
+            failure feedback is appended to it between attempts, so entries
+            left by an exhausted loop are dropped by the thread's teardown.
+        send_turn: Sends one combined user turn to the backing session and
+            returns its result text.
+
+    Returns:
+        The first turn result that satisfies ``post_conditions`` (or the
+        sole turn's result when there are none).
+
+    Emits:
+        MESSAGE_USER — one per drained inject-buffer entry, plus one for
+        ``prompt`` on the first attempt.
+
+    Raises:
+        AIFunctionError: ``post_conditions`` were not satisfied within
+            ``max_attempts`` attempts.
+    """
+    effective_attempts = max(1, max_attempts) if post_conditions else 1
+
+    for attempt in range(effective_attempts):
+        pending = list(inject_buffer)
+        inject_buffer.clear()
+
+        parts: list[str] = []
+        for injected in pending:
+            ctx.on_event(MessageUserEvent(text=injected))
+            parts.append(injected)
+        if attempt == 0:
+            ctx.on_event(MessageUserEvent(text=prompt))
+            parts.append(prompt)
+        combined = "\n\n".join(parts)
+
+        result = await send_turn(combined)
+
+        if not post_conditions:
+            return result
+
+        errors = await evaluate_post_conditions(result, post_conditions)
+        if not errors:
+            return result
+
+        failures = "\n".join(f"- {e}" for e in errors)
+        inject_buffer.append(
+            f"[{thread_name}] Post-condition failures (attempt {attempt + 1}/{effective_attempts}):\n{failures}",
+        )
+
+    raise AIFunctionError(
+        f"Post-conditions not satisfied after {effective_attempts} attempt(s)",
+        function_name=thread_name,
+    )

--- a/src/ai_functions/claude_code/claude_code.py
+++ b/src/ai_functions/claude_code/claude_code.py
@@ -40,6 +40,9 @@ emitted by the runtime dispatcher, never by the thread.
 - ``SystemMessage`` variants (``TaskStartedMessage``, ``TaskProgressMessage``,
   ``TaskNotificationMessage``, ``MirrorErrorMessage``, …):
   ``CustomEvent(kind=f"claude_system_{subtype}", payload=...)``.
+- Any other member of the SDK's ``Message`` union (it grows across releases):
+  ``CustomEvent(kind="claude_message", payload=...)`` with the dataclass fields
+  flattened — unknown messages degrade to observability, never to an error.
 
 Invariants:
     I2 — every emitted event goes through ``Coordinator.append_event``.
@@ -239,6 +242,15 @@ def _system_message_payload(message: SystemMessage) -> dict[str, object]:
         for field in dataclasses.fields(message):
             if field.name in ("subtype", "data"):
                 continue
+            payload[field.name] = getattr(message, field.name)
+    return payload
+
+
+def _unknown_message_payload(message: Message) -> dict[str, object]:
+    """Flatten an SDK message this adapter has no mapping for to a payload dict."""
+    payload: dict[str, object] = {"message_type": type(message).__name__}
+    if dataclasses.is_dataclass(message) and not isinstance(message, type):
+        for field in dataclasses.fields(message):
             payload[field.name] = getattr(message, field.name)
     return payload
 
@@ -647,11 +659,18 @@ class ClaudeAgentThread(Thread[[str], str]):
                 ),
             )
             return None
+        if isinstance(message, SystemMessage):
+            ctx.on_event(
+                CustomEvent(
+                    kind=f"claude_system_{message.subtype}",
+                    payload=_system_message_payload(message),
+                ),
+            )
+            return None
+        # The ``Message`` union grows with the SDK; degrade members we don't know
+        # to observability rather than raising AttributeError on ``subtype``.
         ctx.on_event(
-            CustomEvent(
-                kind=f"claude_system_{message.subtype}",
-                payload=_system_message_payload(message),
-            ),
+            CustomEvent(kind="claude_message", payload=_unknown_message_payload(message)),
         )
         return None
 

--- a/src/ai_functions/claude_code/claude_code.py
+++ b/src/ai_functions/claude_code/claude_code.py
@@ -35,6 +35,8 @@ emitted by the runtime dispatcher, never by the thread.
   per-``AssistantMessage`` totals) so usage is never double-counted.
 - ``RateLimitEvent``: ``CustomEvent(kind="claude_rate_limit", payload=...)``.
   Observability only — does not currently drive ``Coordinator.pause_signal``.
+- ``ConversationResetMessage``: ``CustomEvent(kind="claude_conversation_reset",
+  payload=...)`` carrying the new conversation id.
 - ``SystemMessage`` variants (``TaskStartedMessage``, ``TaskProgressMessage``,
   ``TaskNotificationMessage``, ``MirrorErrorMessage``, …):
   ``CustomEvent(kind=f"claude_system_{subtype}", payload=...)``.
@@ -56,6 +58,7 @@ from claude_agent_sdk import (
     AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
+    ConversationResetMessage,
     McpServerConfig,
     Message,
     PermissionResult,
@@ -629,6 +632,19 @@ class ClaudeAgentThread(Thread[[str], str]):
         if isinstance(message, RateLimitEvent):
             ctx.on_event(
                 CustomEvent(kind="claude_rate_limit", payload=_rate_limit_payload(message)),
+            )
+            return None
+        if isinstance(message, ConversationResetMessage):
+            # Not a SystemMessage — it carries ids, no subtype.
+            ctx.on_event(
+                CustomEvent(
+                    kind="claude_conversation_reset",
+                    payload={
+                        "new_conversation_id": message.new_conversation_id,
+                        "uuid": message.uuid,
+                        "session_id": message.session_id,
+                    },
+                ),
             )
             return None
         ctx.on_event(

--- a/src/ai_functions/claude_code/claude_code.py
+++ b/src/ai_functions/claude_code/claude_code.py
@@ -80,8 +80,7 @@ from strands.tools.decorator import tool as _strands_tool  # pyright: ignore[rep
 from strands.types.interrupt import InterruptResponseContent
 from strands.types.tools import AgentTool
 
-from ..ai_thread.errors import AIFunctionError
-from ..ai_thread.postcondition import PostCondition
+from ..ai_thread.postcondition import PostCondition, run_post_condition_loop
 from ..protocols import Spawnable, Thread
 from ..types import (
     CustomEvent,
@@ -91,7 +90,6 @@ from ..types import (
     MessageAssistantThinkingEvent,
     MessageAssistantTokenEvent,
     MessageId,
-    MessageUserEvent,
     ThreadContext,
     TokenUsage,
     TokenUsageEvent,
@@ -461,90 +459,22 @@ class ClaudeAgentThread(Thread[[str], str]):
         try:
             await self._ensure_connected()
 
-            post_conditions = self._template.post_conditions
-            max_attempts = self._template.max_attempts if post_conditions else 1
-
-            result = ""
-            for attempt in range(max(1, max_attempts)):
-                # Drain inject buffer: each pending message is emitted as its
-                # own MESSAGE_USER event, then prepended to the outgoing turn.
-                # On the first attempt the buffer holds any caller-supplied
-                # side-channel messages; on retries it holds the
-                # post-condition failure feedback appended below. The original
-                # ``prompt`` is only sent on the first attempt — the SDK owns
-                # the conversation history, so retries ride the feedback turn
-                # (mirrors ``AIThread``: failures are injected as the next
-                # user turn, the task stays in context).
-                pending = list(self._inject_buffer)
-                self._inject_buffer.clear()
-
-                parts: list[str] = []
-                for injected in pending:
-                    ctx.on_event(MessageUserEvent(text=injected))
-                    parts.append(injected)
-                if attempt == 0:
-                    ctx.on_event(MessageUserEvent(text=prompt))
-                    parts.append(prompt)
-                combined = "\n\n".join(parts)
-
+            async def _send_turn(combined: str) -> str:
                 assert self._client is not None
                 await self._client.query(combined)
-                result = await self._consume_stream(ctx)
+                return await self._consume_stream(ctx)
 
-                if not post_conditions:
-                    return result
-
-                errors = await self._validate_result(result, post_conditions)
-                if not errors:
-                    return result
-
-                # Feed failures back as the next user turn and retry.
-                failures = "\n".join(f"- {e}" for e in errors)
-                self._inject_buffer.append(
-                    f"[{self.name}] Post-condition failures (attempt {attempt + 1}/{max_attempts}):\n{failures}"
-                )
-
-            raise AIFunctionError(
-                f"Post-conditions not satisfied after {max_attempts} attempt(s)",
-                function_name=self.name,
+            return await run_post_condition_loop(
+                ctx,
+                prompt,
+                thread_name=self.name,
+                post_conditions=self._template.post_conditions,
+                max_attempts=self._template.max_attempts,
+                inject_buffer=self._inject_buffer,
+                send_turn=_send_turn,
             )
         finally:
             self._active_ctx = None
-
-    async def _validate_result(
-        self,
-        result: str,
-        post_conditions: tuple[PostCondition, ...],
-    ) -> list[str]:
-        """Evaluate every post-condition against ``result`` in parallel.
-
-        Mirrors ``AIThread._validate_result``: a condition returning
-        ``None``/``passed`` passes; ``passed=False`` contributes its message;
-        a raised exception is treated as failure with the exception text.
-        ``ClaudeAgentThread`` takes a single string prompt, so there are no
-        bound keyword arguments to offer condition callables.
-
-        Args:
-            result: The candidate result string from the Claude Agent stream.
-            post_conditions: Validators to run.
-
-        Returns:
-            Failure messages; empty when all conditions pass.
-        """
-
-        async def _run_one(cond: PostCondition) -> str | None:
-            try:
-                cond_result = cond(result)
-                if asyncio.iscoroutine(cond_result):
-                    cond_result = await cond_result
-            except Exception as exc:
-                return str(exc)
-            if cond_result is None or cond_result.passed:
-                return None
-            return cond_result.message
-
-        outcomes = await asyncio.gather(*(_run_one(c) for c in post_conditions))
-        return [msg for msg in outcomes if msg is not None]
 
     async def fork(self) -> Spawnable[[str], str]:
         """Not supported.

--- a/src/ai_functions/kiro/kiro.py
+++ b/src/ai_functions/kiro/kiro.py
@@ -63,8 +63,7 @@ from strands.types.content import ContentBlock
 from strands.types.interrupt import InterruptResponseContent
 from strands.types.tools import AgentTool, ToolResultContent, ToolResultStatus
 
-from ..ai_thread.errors import AIFunctionError
-from ..ai_thread.postcondition import PostCondition
+from ..ai_thread.postcondition import PostCondition, run_post_condition_loop
 from ..protocols import Spawnable, Thread
 from ..types import (
     InputShape,
@@ -73,7 +72,6 @@ from ..types import (
     MessageAssistantThinkingEvent,
     MessageAssistantTokenEvent,
     MessageId,
-    MessageUserEvent,
     ThreadContext,
     TokenUsage,
     TokenUsageEvent,
@@ -433,46 +431,17 @@ class KiroAgentThread(Thread[[str], str]):
         try:
             await self._ensure_connected()
 
-            post_conditions = self._template.post_conditions
-            max_attempts = self._template.max_attempts if post_conditions else 1
+            async def _send_turn(combined: str) -> str:
+                return await self._run_turn(ctx, combined)
 
-            result = ""
-            for attempt in range(max(1, max_attempts)):
-                # Drain inject buffer: each pending message is emitted as its
-                # own MESSAGE_USER event, then prepended to the outgoing turn.
-                # On retries the buffer holds the post-condition failure
-                # feedback appended below; the original prompt is sent only on
-                # the first attempt — the ACP session owns history, so retries
-                # ride the feedback turn.
-                pending = list(self._inject_buffer)
-                self._inject_buffer.clear()
-
-                parts: list[str] = []
-                for injected in pending:
-                    ctx.on_event(MessageUserEvent(text=injected))
-                    parts.append(injected)
-                if attempt == 0:
-                    ctx.on_event(MessageUserEvent(text=prompt))
-                    parts.append(prompt)
-                combined = "\n\n".join(parts)
-
-                result = await self._run_turn(ctx, combined)
-
-                if not post_conditions:
-                    return result
-
-                errors = await self._validate_result(result, post_conditions)
-                if not errors:
-                    return result
-
-                failures = "\n".join(f"- {e}" for e in errors)
-                self._inject_buffer.append(
-                    f"[{self.name}] Post-condition failures (attempt {attempt + 1}/{max_attempts}):\n{failures}",
-                )
-
-            raise AIFunctionError(
-                f"Post-conditions not satisfied after {max_attempts} attempt(s)",
-                function_name=self.name,
+            return await run_post_condition_loop(
+                ctx,
+                prompt,
+                thread_name=self.name,
+                post_conditions=self._template.post_conditions,
+                max_attempts=self._template.max_attempts,
+                inject_buffer=self._inject_buffer,
+                send_turn=_send_turn,
             )
         finally:
             self._active_ctx = None
@@ -598,40 +567,6 @@ class KiroAgentThread(Thread[[str], str]):
         if usage is not None:
             ctx.on_event(TokenUsageEvent(token_usage=usage))
         return "".join(turn.text_parts)
-
-    async def _validate_result(
-        self,
-        result: str,
-        post_conditions: tuple[PostCondition, ...],
-    ) -> list[str]:
-        """Evaluate every post-condition against ``result`` in parallel.
-
-        A condition returning ``None``/``passed`` passes; ``passed=False``
-        contributes its message; a raised exception is treated as failure with
-        the exception text. ``KiroAgentThread`` takes a single string prompt, so
-        there are no bound keyword arguments to offer condition callables.
-
-        Args:
-            result: The candidate result string for the turn.
-            post_conditions: Validators to run.
-
-        Returns:
-            Failure messages; empty when all conditions pass.
-        """
-
-        async def _run_one(cond: PostCondition) -> str | None:
-            try:
-                cond_result = cond(result)
-                if asyncio.iscoroutine(cond_result):
-                    cond_result = await cond_result
-            except Exception as exc:  # noqa: BLE001 - any failure is a failed condition
-                return str(exc)
-            if cond_result is None or cond_result.passed:
-                return None
-            return cond_result.message
-
-        outcomes = await asyncio.gather(*(_run_one(c) for c in post_conditions))
-        return [msg for msg in outcomes if msg is not None]
 
     # ── ACP client callbacks (invoked from the connection's read loop) ──
 

--- a/src/ai_functions/kiro/kiro.py
+++ b/src/ai_functions/kiro/kiro.py
@@ -87,7 +87,6 @@ try:
         Client as _AcpClient,
     )
     from acp import (
-        ClientSideConnection,
         RequestPermissionResponse,
     )
     from acp.schema import (
@@ -109,6 +108,10 @@ except ImportError as exc:  # pragma: no cover - exercised only without the extr
     ) from exc
 
 if TYPE_CHECKING:
+    # Annotation-only: ``ClientSideConnection`` is deprecated for direct runtime
+    # use (``acp.connect_to_agent`` supersedes it) but remains the type of the
+    # connection ``acp.spawn_agent_process`` yields.
+    from acp import ClientSideConnection
     from acp.schema import (
         AgentPlanUpdate,
         AvailableCommandsUpdate,

--- a/src/ai_functions/kiro/kiro.py
+++ b/src/ai_functions/kiro/kiro.py
@@ -113,6 +113,8 @@ if TYPE_CHECKING:
     # connection ``acp.spawn_agent_process`` yields.
     from acp import ClientSideConnection
     from acp.schema import (
+        AgentPlanContentUpdate,
+        AgentPlanRemovedUpdate,
         AgentPlanUpdate,
         AvailableCommandsUpdate,
         ConfigOptionUpdate,
@@ -756,6 +758,8 @@ class _KiroAcpClient(_AcpClient):
         | ToolCallStart
         | ToolCallProgress
         | AgentPlanUpdate
+        | AgentPlanContentUpdate
+        | AgentPlanRemovedUpdate
         | AvailableCommandsUpdate
         | CurrentModeUpdate
         | ConfigOptionUpdate
@@ -769,13 +773,28 @@ class _KiroAcpClient(_AcpClient):
     @override
     async def request_permission(
         self,
-        options: list[PermissionOption],
         session_id: str,
         tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
         **kwargs: object,
     ) -> RequestPermissionResponse:
-        """Resolve a permission request via the owning thread."""
+        """Resolve a permission request via the owning thread.
+
+        The connection router invokes client methods by keyword, so parameter
+        order is free — this matches the ``acp.Client`` declaration so the
+        override checks structurally.
+        """
         return await self._thread._handle_permission(options, tool_call)  # pyright: ignore[reportPrivateUsage]
+
+    @override
+    async def create_elicitation(self, *args: object, **kwargs: object) -> NoReturn:
+        """Unsupported; ``elicitation`` capability is not advertised."""
+        raise acp.exceptions.RequestError(code=-32601, message="session/create_elicitation not supported")
+
+    @override
+    async def complete_elicitation(self, *args: object, **kwargs: object) -> NoReturn:
+        """Unsupported; ``elicitation`` capability is not advertised."""
+        raise acp.exceptions.RequestError(code=-32601, message="session/complete_elicitation not supported")
 
     @override
     async def read_text_file(self, *args: object, **kwargs: object) -> NoReturn:

--- a/tests/test_postcondition_loop.py
+++ b/tests/test_postcondition_loop.py
@@ -1,0 +1,214 @@
+"""The shared post-condition retry loop for session-owned-history threads.
+
+``run_post_condition_loop`` is the cycle body of ``ClaudeAgentThread`` and
+``KiroAgentThread``. These tests drive it with a fake ``send_turn`` and a
+recording ``ThreadContext``, pinning the contract both backends rely on:
+the prompt is sent exactly once, retries carry only the failure feedback,
+every outgoing part gets its own ``MESSAGE_USER`` event, and exhaustion
+raises ``AIFunctionError``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ai_functions.ai_thread.errors import AIFunctionError
+from ai_functions.ai_thread.postcondition import (
+    PostConditionResult,
+    evaluate_post_conditions,
+    run_post_condition_loop,
+)
+from ai_functions.types import Event, MessageUserEvent, ThreadContext, ThreadId
+from ai_functions.types.events import EventKind
+
+
+class _Recorder:
+    """Collects the loop's interactions: events emitted and turns sent."""
+
+    def __init__(self, replies: list[str]) -> None:
+        self.events: list[Event] = []
+        self.sent: list[str] = []
+        self._replies = replies
+
+    def ctx(self) -> ThreadContext:
+        return ThreadContext(
+            thread_id=ThreadId("t-loop"),
+            coordinator=None,  # type: ignore[arg-type]  # the loop never touches it
+            on_event=self.events.append,
+            on_interrupt=None,  # type: ignore[arg-type]  # the loop never touches it
+            pause_signal=asyncio.Event(),
+            cancel_signal=asyncio.Event(),
+        )
+
+    async def send_turn(self, combined: str) -> str:
+        self.sent.append(combined)
+        return self._replies[len(self.sent) - 1]
+
+    def user_messages(self) -> list[str]:
+        return [e.text for e in self.events if e.kind == EventKind.MESSAGE_USER and isinstance(e, MessageUserEvent)]
+
+
+def _fail(message: str):  # noqa: ANN202 - test helper factory
+    def cond(result: str) -> PostConditionResult:
+        return PostConditionResult(passed=False, message=message)
+
+    return cond
+
+
+def _pass_when(expected: str):  # noqa: ANN202 - test helper factory
+    def cond(result: str) -> PostConditionResult:
+        if result == expected:
+            return PostConditionResult(passed=True)
+        return PostConditionResult(passed=False, message=f"expected {expected!r}, got {result!r}")
+
+    return cond
+
+
+async def test_no_post_conditions_is_a_single_turn() -> None:
+    """Empty post_conditions short-circuits after one turn, whatever max_attempts says."""
+    rec = _Recorder(replies=["first answer"])
+    result = await run_post_condition_loop(
+        rec.ctx(),
+        "do the task",
+        thread_name="t",
+        post_conditions=(),
+        max_attempts=10,
+        inject_buffer=[],
+        send_turn=rec.send_turn,
+    )
+    assert result == "first answer"
+    assert rec.sent == ["do the task"]
+    assert rec.user_messages() == ["do the task"]
+
+
+async def test_inject_buffer_prepends_and_emits_per_entry() -> None:
+    """Each pending side-channel message gets its own MESSAGE_USER and precedes the prompt."""
+    rec = _Recorder(replies=["ok"])
+    buffer = ["note one", "note two"]
+    result = await run_post_condition_loop(
+        rec.ctx(),
+        "the prompt",
+        thread_name="t",
+        post_conditions=(),
+        max_attempts=1,
+        inject_buffer=buffer,
+        send_turn=rec.send_turn,
+    )
+    assert result == "ok"
+    assert rec.sent == ["note one\n\nnote two\n\nthe prompt"]
+    assert rec.user_messages() == ["note one", "note two", "the prompt"]
+    assert buffer == []
+
+
+async def test_retry_rides_feedback_and_never_resends_prompt() -> None:
+    """On failure the next turn carries only the feedback; the prompt is sent once."""
+    rec = _Recorder(replies=["wrong", "RIGHT"])
+    result = await run_post_condition_loop(
+        rec.ctx(),
+        "answer with RIGHT",
+        thread_name="checker",
+        post_conditions=(_pass_when("RIGHT"),),
+        max_attempts=5,
+        inject_buffer=[],
+        send_turn=rec.send_turn,
+    )
+    assert result == "RIGHT"
+    assert len(rec.sent) == 2
+    assert rec.sent[0] == "answer with RIGHT"
+    # The retry turn is the feedback alone — the session already holds the prompt.
+    assert "answer with RIGHT" not in rec.sent[1]
+    assert "[checker] Post-condition failures (attempt 1/5)" in rec.sent[1]
+    assert "expected 'RIGHT', got 'wrong'" in rec.sent[1]
+    # Feedback is a user turn, so it is also shadowed as MESSAGE_USER.
+    assert len(rec.user_messages()) == 2
+
+
+async def test_exhaustion_raises_with_thread_attribution() -> None:
+    """max_attempts failures raise AIFunctionError naming the thread."""
+    rec = _Recorder(replies=["a", "b", "c"])
+    with pytest.raises(AIFunctionError) as exc_info:
+        await run_post_condition_loop(
+            rec.ctx(),
+            "task",
+            thread_name="stubborn",
+            post_conditions=(_fail("nope"),),
+            max_attempts=3,
+            inject_buffer=[],
+            send_turn=rec.send_turn,
+        )
+    assert "3 attempt(s)" in str(exc_info.value)
+    assert exc_info.value.function_name == "stubborn"
+    assert len(rec.sent) == 3
+
+
+async def test_multiple_failures_are_all_fed_back() -> None:
+    """Every failing condition contributes one bullet to the feedback turn."""
+    rec = _Recorder(replies=["draft", "still draft"])
+    with pytest.raises(AIFunctionError):
+        await run_post_condition_loop(
+            rec.ctx(),
+            "write",
+            thread_name="t",
+            post_conditions=(_fail("too terse"), _fail("missing citation")),
+            max_attempts=2,
+            inject_buffer=[],
+            send_turn=rec.send_turn,
+        )
+    feedback = rec.sent[1]
+    assert "- too terse" in feedback
+    assert "- missing citation" in feedback
+
+
+async def test_all_conditions_must_pass_to_return() -> None:
+    """One passing condition does not mask another's failure."""
+    rec = _Recorder(replies=["draft ok", "draft ok"])
+    with pytest.raises(AIFunctionError):
+        await run_post_condition_loop(
+            rec.ctx(),
+            "write",
+            thread_name="t",
+            post_conditions=(_pass_when("draft ok"), _fail("style: too terse")),
+            max_attempts=2,
+            inject_buffer=[],
+            send_turn=rec.send_turn,
+        )
+    # Only the failing condition appears in the feedback.
+    assert "style: too terse" in rec.sent[1]
+    assert "expected" not in rec.sent[1]
+
+
+async def test_condition_exception_is_a_failure_message() -> None:
+    """A raising condition fails with the exception text instead of crashing the loop."""
+
+    def explode(result: str) -> PostConditionResult:
+        raise ValueError("validator blew up")
+
+    errors = await evaluate_post_conditions("anything", (explode,))
+    assert errors == ["validator blew up"]
+
+
+async def test_async_conditions_are_awaited() -> None:
+    """Coroutine-returning conditions are awaited, matching the sync path."""
+
+    async def slow_pass(result: str) -> PostConditionResult:
+        await asyncio.sleep(0)
+        return PostConditionResult(passed=True)
+
+    async def slow_fail(result: str) -> PostConditionResult:
+        await asyncio.sleep(0)
+        return PostConditionResult(passed=False, message="slow no")
+
+    errors = await evaluate_post_conditions("x", (slow_pass, slow_fail))
+    assert errors == ["slow no"]
+
+
+async def test_none_result_counts_as_pass() -> None:
+    """A condition returning None passes."""
+
+    def silent(result: str) -> None:
+        return None
+
+    errors = await evaluate_post_conditions("x", (silent,))
+    assert errors == []


### PR DESCRIPTION
**Stack position: 2 of 4**, on top of #35 (ACP 0.12 pin). Until #35 merges this PR shows its commits too; after the squash-merge I rebase and the diff collapses to the two commits below.

## Commit 1 — the extraction

`ClaudeAgentThread.execute` and `KiroAgentThread.execute` carried the same cycle body — drain the inject buffer with one `MESSAGE_USER` per entry, send the prompt only on the first attempt, feed post-condition failures back as the next user turn, raise `AIFunctionError` on exhaustion — and `_validate_result` was duplicated verbatim. Both move into `ai_thread/postcondition.py` as `run_post_condition_loop` / `evaluate_post_conditions`, parameterized on a `send_turn` callable; the two `execute` bodies reduce to transport-specific turn senders (−70 lines each, net).

The loop applies to threads whose backing session owns its own conversation history (retries never replay the prompt). `AIThread` keeps its own loop deliberately: it owns its history and offers bound keyword arguments to condition callables, which these single-string-prompt threads don't have.

**New coverage where there was none.** Neither backend's copy of this logic had a single test. The shared loop now has direct unit tests (`tests/test_postcondition_loop.py`, 9 tests, fake `send_turn` + recording ctx): prompt sent exactly once, retries ride the feedback turn alone, one `MESSAGE_USER` per outgoing part, all conditions must pass for a return, async conditions awaited, condition exceptions become failure messages, exhaustion raises with thread attribution.

This is also pre-work for the Codex backend (stack position 4), which would otherwise be the third verbatim copy.

## Commit 2 — a crash found by pyright along the way

The SDK's `Message` union includes `ConversationResetMessage`, which is not a `SystemMessage` and has no `subtype` — the system-message fall-through in `_emit_events_for` raises `AttributeError` if one arrives mid-stream. It now maps to `CustomEvent(kind="claude_conversation_reset")` carrying the new conversation id, matching the rate-limit shadowing pattern. Pre-existing on main; fixed here because this PR already touches the file.

Checks: 418 passed / 2 skipped (9 new), ruff clean, stubtest clean, pyright 0 errors on all three touched source files.
