### PR TITLE
feat(runtime): CoordinatorToolServer — the runtime tools over HTTP MCP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ kiro = [
 agentcore = [
     "bedrock-agentcore>=1.6.0",
 ]
+runtime-tools = [
+    "mcp>=1.29",
+    "uvicorn>=0.30",
+]
 
 [project.scripts]
 ai-functions = "ai_functions.cli:main"
@@ -90,6 +94,8 @@ dependencies = [
     "textual>=0.70",
     "platformdirs>=4.0",
     "agent-client-protocol>=0.12.1,<0.13",
+    "mcp>=1.29",
+    "uvicorn>=0.30",
     "pyyaml>=6.0",
     "bedrock-agentcore>=1.6.0",
     "rank-bm25>=0.2.2",

--- a/spec/ai_functions/runtime/tool_server.pyi
+++ b/spec/ai_functions/runtime/tool_server.pyi
@@ -1,0 +1,154 @@
+"""``CoordinatorToolServer`` — the runtime tools over streamable-HTTP MCP.
+
+Serves the two coordinator tools from
+:mod:`ai_functions.runtime.coordinator_tools_core` (``list_threads`` /
+``send_message``) to any MCP-speaking agent runtime over HTTP, so foreign
+backends that cannot host an in-process MCP server (Codex, Kiro, anything
+else with an ``mcp_servers`` config) can join a team without per-runtime
+bridge code.
+
+One server per worker; each thread registers to receive its own capability
+URL of the form ``http://<host>:<port>/mcp/<token>``.
+
+Security model: the port is reachable by any local process, so the *token*
+is the boundary. Each registration mints a ``secrets``-grade token that must
+appear both in the URL path and in the ``Authorization: Bearer`` header
+(constant-time compared); the ``Host`` header must resolve to the bound host
+(DNS-rebinding defense per the MCP spec's guidance for local HTTP servers);
+deregistration revokes the token immediately.
+
+The MCP app runs stateless (``stateless_http=True``): tools and one-shot
+reads only — no server-initiated messages, no resource subscriptions.
+
+Requires the ``runtime-tools`` extra (``mcp``, ``uvicorn``).
+"""
+
+from dataclasses import dataclass
+from typing import final
+
+from ..protocols import Coordinator
+from ..types import ThreadId
+
+DEFAULT_PORT: int
+"""Default fixed port. Fixed (not ephemeral) by design: MCP URL allowlists
+(e.g. Claude Code's ``allowedMcpServers``) match on URL patterns that must be
+written before the server exists, so one glob like ``http://127.0.0.1:8787/*``
+can cover every thread for the deployment's lifetime."""
+
+@dataclass(frozen=True)
+class ToolServerRegistration:
+    """One thread's capability to call the runtime tools."""
+
+    url: str
+    """Full MCP endpoint for this thread, token embedded in the path."""
+
+    token: str
+    """The bare secret, for transports that pass it out of band (e.g. Codex's
+    ``bearer_token_env_var``). Required in the ``Authorization: Bearer`` header
+    on every request."""
+
+@final
+class CoordinatorToolServer:
+    """One streamable-HTTP MCP server hosting the runtime tools for a worker.
+
+    Lifecycle:
+        constructed → ``start()`` (binds and serves) → ``register`` /
+        ``deregister`` per thread → ``stop()``.
+
+    Concurrency:
+        ``start``/``stop`` are owned by the hosting worker's event loop.
+        ``register``/``deregister`` are synchronous dict operations, safe to
+        call between requests; per-request identity travels in a context
+        variable, so concurrent requests for different threads never observe
+        each other's registration.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str = "127.0.0.1",
+        port: int = ...,
+        fallback_to_ephemeral: bool = True,
+    ) -> None:
+        """Configure the server; nothing binds until :meth:`start`.
+
+        Args:
+            host: Interface to bind. The default serves local agent
+                subprocesses only; binding wider is the caller's decision and
+                should come with real network auth in front.
+            port: Fixed port to bind, :data:`DEFAULT_PORT` by default — see
+                its docstring for why fixed. ``0`` requests an ephemeral port
+                outright.
+            fallback_to_ephemeral: When the fixed port is taken, bind an
+                ephemeral one instead of failing. The fallback logs a warning
+                because a URL allowlist written for the fixed port will not
+                match it.
+        """
+        ...
+
+    async def start(self) -> None:
+        """Bind the socket and serve until :meth:`stop`.
+
+        Ensures:
+            - :attr:`base_url` is valid once this returns.
+            - Requests are answered (all-404 until a thread registers).
+
+        Raises:
+            OSError: The fixed port is taken and ``fallback_to_ephemeral``
+                is false.
+
+        Concurrency:
+            Idempotent; a started server ignores further ``start`` calls.
+        """
+        ...
+
+    async def stop(self) -> None:
+        """Stop serving and revoke every registration.
+
+        Concurrency:
+            Idempotent; stopping a never-started server is a no-op.
+        """
+        ...
+
+    @property
+    def base_url(self) -> str:
+        """Root URL of the running server (no token).
+
+        Raises:
+            RuntimeError: The server is not started.
+        """
+        ...
+
+    @property
+    def port(self) -> int | None:
+        """The bound port while running, else ``None``."""
+        ...
+
+    def register(self, coordinator: Coordinator, thread_id: ThreadId) -> ToolServerRegistration:
+        """Mint a capability URL through which ``thread_id`` calls the tools.
+
+        Re-registering a thread revokes its previous token and mints a fresh
+        one.
+
+        Args:
+            coordinator: Coordinator the tools act on for this thread.
+            thread_id: Identity the tools act *as* — ``is_self`` marking,
+                ``send_message`` sender, and the reply target of
+                ``continue_then_receive``.
+
+        Returns:
+            The registration; hand ``url`` (and, for out-of-band transports,
+            ``token``) to the agent runtime's MCP config.
+
+        Raises:
+            RuntimeError: The server is not started.
+        """
+        ...
+
+    def deregister(self, thread_id: ThreadId) -> None:
+        """Revoke ``thread_id``'s token; requests with it fail immediately.
+
+        Concurrency:
+            Idempotent; deregistering an unknown thread is a no-op.
+        """
+        ...

--- a/spec/ai_functions/runtime/tool_server.pyi
+++ b/spec/ai_functions/runtime/tool_server.pyi
@@ -2,10 +2,11 @@
 
 Serves the two coordinator tools from
 :mod:`ai_functions.runtime.coordinator_tools_core` (``list_threads`` /
-``send_message``) to any MCP-speaking agent runtime over HTTP, so foreign
-backends that cannot host an in-process MCP server (Codex, Kiro, anything
-else with an ``mcp_servers`` config) can join a team without per-runtime
-bridge code.
+``send_message``) over HTTP, so agent runtimes that take an ``mcp_servers`` URL
+— Codex among them — can join a team without per-runtime bridge code. Runs in
+the process owning the coordinator.
+
+Clients must send the token in the ``Authorization: Bearer`` header.
 
 One server per worker; each thread registers to receive its own capability
 URL of the form ``http://<host>:<port>/mcp/<token>``.
@@ -13,9 +14,10 @@ URL of the form ``http://<host>:<port>/mcp/<token>``.
 Security model: the port is reachable by any local process, so the *token*
 is the boundary. Each registration mints a ``secrets``-grade token that must
 appear both in the URL path and in the ``Authorization: Bearer`` header
-(constant-time compared); the ``Host`` header must resolve to the bound host
-(DNS-rebinding defense per the MCP spec's guidance for local HTTP servers);
-deregistration revokes the token immediately.
+(constant-time compared); the ``Host`` header must name the bound host or a
+loopback alias (DNS-rebinding defense per the MCP spec's guidance for local
+HTTP servers); deregistration revokes the token immediately. The bind host is
+loopback.
 
 The MCP app runs stateless (``stateless_http=True``): tools and one-shot
 reads only — no server-initiated messages, no resource subscriptions.
@@ -73,9 +75,7 @@ class CoordinatorToolServer:
         """Configure the server; nothing binds until :meth:`start`.
 
         Args:
-            host: Interface to bind. The default serves local agent
-                subprocesses only; binding wider is the caller's decision and
-                should come with real network auth in front.
+            host: Loopback interface to bind.
             port: Fixed port to bind, :data:`DEFAULT_PORT` by default — see
                 its docstring for why fixed. ``0`` requests an ephemeral port
                 outright.
@@ -83,6 +83,9 @@ class CoordinatorToolServer:
                 ephemeral one instead of failing. The fallback logs a warning
                 because a URL allowlist written for the fixed port will not
                 match it.
+
+        Raises:
+            ValueError: ``host`` is not a loopback address.
         """
         ...
 
@@ -96,6 +99,7 @@ class CoordinatorToolServer:
         Raises:
             OSError: The fixed port is taken and ``fallback_to_ephemeral``
                 is false.
+            TimeoutError: Serving did not come up within the startup timeout.
 
         Concurrency:
             Idempotent; a started server ignores further ``start`` calls.
@@ -104,6 +108,10 @@ class CoordinatorToolServer:
 
     async def stop(self) -> None:
         """Stop serving and revoke every registration.
+
+        In-flight tool calls are dropped rather than drained: a client waiting
+        on one (``send_message(mode="wait")``, say) sees the connection close
+        mid-response.
 
         Concurrency:
             Idempotent; stopping a never-started server is a no-op.
@@ -146,7 +154,10 @@ class CoordinatorToolServer:
         ...
 
     def deregister(self, thread_id: ThreadId) -> None:
-        """Revoke ``thread_id``'s token; requests with it fail immediately.
+        """Revoke ``thread_id``'s token; later requests with it 404.
+
+        A request already dispatched keeps the registration it resolved for the
+        rest of its lifetime; revocation is not a cancellation.
 
         Concurrency:
             Idempotent; deregistering an unknown thread is a no-op.

--- a/spec/ai_functions/runtime/tool_server.pyi
+++ b/spec/ai_functions/runtime/tool_server.pyi
@@ -9,15 +9,15 @@ the process owning the coordinator.
 Clients must send the token in the ``Authorization: Bearer`` header.
 
 One server per worker; each thread registers to receive its own capability
-URL of the form ``http://<host>:<port>/mcp/<token>``.
+URL of the form ``http://127.0.0.1:<port>/mcp/<token>``.
 
-Security model: the port is reachable by any local process, so the *token*
-is the boundary. Each registration mints a ``secrets``-grade token that must
-appear both in the URL path and in the ``Authorization: Bearer`` header
-(constant-time compared); the ``Host`` header must name the bound host or a
-loopback alias (DNS-rebinding defense per the MCP spec's guidance for local
-HTTP servers); deregistration revokes the token immediately. The bind host is
-loopback.
+The server binds 127.0.0.1 on a system-assigned port; pass the registration URL
+to the runtime as it starts. The port is reachable by any local process, so the
+*token* is the boundary: each registration mints a ``secrets``-grade token that
+must appear both in the URL path and in the ``Authorization: Bearer`` header
+(constant-time compared), the ``Host`` header must name the bound address
+(DNS-rebinding defense per the MCP spec's guidance for local HTTP servers), and
+deregistration revokes the token immediately.
 
 The MCP app runs stateless (``stateless_http=True``): tools and one-shot
 reads only — no server-initiated messages, no resource subscriptions.
@@ -30,12 +30,6 @@ from typing import final
 
 from ..protocols import Coordinator
 from ..types import ThreadId
-
-DEFAULT_PORT: int
-"""Default fixed port. Fixed (not ephemeral) by design: MCP URL allowlists
-(e.g. Claude Code's ``allowedMcpServers``) match on URL patterns that must be
-written before the server exists, so one glob like ``http://127.0.0.1:8787/*``
-can cover every thread for the deployment's lifetime."""
 
 @dataclass(frozen=True)
 class ToolServerRegistration:
@@ -65,28 +59,8 @@ class CoordinatorToolServer:
         each other's registration.
     """
 
-    def __init__(
-        self,
-        *,
-        host: str = "127.0.0.1",
-        port: int = ...,
-        fallback_to_ephemeral: bool = True,
-    ) -> None:
-        """Configure the server; nothing binds until :meth:`start`.
-
-        Args:
-            host: Loopback interface to bind.
-            port: Fixed port to bind, :data:`DEFAULT_PORT` by default — see
-                its docstring for why fixed. ``0`` requests an ephemeral port
-                outright.
-            fallback_to_ephemeral: When the fixed port is taken, bind an
-                ephemeral one instead of failing. The fallback logs a warning
-                because a URL allowlist written for the fixed port will not
-                match it.
-
-        Raises:
-            ValueError: ``host`` is not a loopback address.
-        """
+    def __init__(self) -> None:
+        """Configure the server; nothing binds until :meth:`start`."""
         ...
 
     async def start(self) -> None:
@@ -97,8 +71,6 @@ class CoordinatorToolServer:
             - Requests are answered (all-404 until a thread registers).
 
         Raises:
-            OSError: The fixed port is taken and ``fallback_to_ephemeral``
-                is false.
             TimeoutError: Serving did not come up within the startup timeout.
 
         Concurrency:
@@ -125,11 +97,6 @@ class CoordinatorToolServer:
         Raises:
             RuntimeError: The server is not started.
         """
-        ...
-
-    @property
-    def port(self) -> int | None:
-        """The bound port while running, else ``None``."""
         ...
 
     def register(self, coordinator: Coordinator, thread_id: ThreadId) -> ToolServerRegistration:

--- a/src/ai_functions/runtime/tool_server.py
+++ b/src/ai_functions/runtime/tool_server.py
@@ -2,10 +2,12 @@
 
 Serves the two coordinator tools from
 :mod:`ai_functions.runtime.coordinator_tools_core` (``list_threads`` /
-``send_message``) to any MCP-speaking agent runtime over HTTP, so foreign
-backends that cannot host an in-process MCP server (Codex, Kiro, anything
-else with an ``mcp_servers`` config) can join a team without per-runtime
-bridge code.
+``send_message``) over HTTP, so agent runtimes that take an ``mcp_servers`` URL
+— Codex among them — can join a team without per-runtime bridge code. Runs in
+the process owning the coordinator.
+
+Clients must send the token in the ``Authorization: Bearer`` header (Codex:
+``codex mcp add --url ... --bearer-token-env-var``).
 
 One server per worker. Each thread registers to receive its own capability
 URL::
@@ -22,9 +24,10 @@ URL::
 Security model: the port is reachable by any local process, so the
 *token* is the boundary. Each registration mints a ``secrets``-grade token
 that must appear both in the URL path and in the ``Authorization: Bearer``
-header (constant-time compared); the ``Host`` header must resolve to the
-bound host (DNS-rebinding defense per the MCP spec's guidance for local
-HTTP servers); deregistration revokes the token immediately.
+header (constant-time compared); the ``Host`` header must name the bound host or
+a loopback alias (DNS-rebinding defense per the MCP spec's guidance for local
+HTTP servers); deregistration revokes the token immediately. The bind host is
+loopback.
 
 The MCP app runs stateless (``stateless_http=True``): tools and one-shot
 reads only — no server-initiated messages, no resource subscriptions.
@@ -39,6 +42,7 @@ import asyncio
 import contextvars
 import errno
 import hmac
+import ipaddress
 import logging
 import secrets
 import socket
@@ -73,6 +77,21 @@ DEFAULT_PORT = 8787
 (e.g. Claude Code's ``allowedMcpServers``) match on URL patterns that must be
 written before the server exists, so one glob like ``http://127.0.0.1:8787/*``
 can cover every thread for the deployment's lifetime."""
+
+_STARTUP_TIMEOUT = 10.0
+"""Seconds to wait for uvicorn to report ``started`` before giving up."""
+
+_LOOPBACK_ALIASES = frozenset({"localhost", "127.0.0.1", "::1"})
+"""Names a loopback-bound server also answers to."""
+
+
+def _is_loopback(host: str) -> bool:
+    """Whether ``host`` names the loopback interface."""
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host.lower() == "localhost"
+
 
 # ASGI shorthands (plain dicts/callables; no framework import needed).
 _Scope = MutableMapping[str, Any]  # pyright: ignore[reportExplicitAny]
@@ -248,9 +267,7 @@ class CoordinatorToolServer:
         """Configure the server; nothing binds until :meth:`start`.
 
         Args:
-            host: Interface to bind. The default serves local agent
-                subprocesses only; binding wider is the caller's decision and
-                should come with real network auth in front.
+            host: Loopback interface to bind.
             port: Fixed port to bind. Fixed by design — see
                 :data:`DEFAULT_PORT`. ``0`` requests an ephemeral port
                 outright.
@@ -258,7 +275,12 @@ class CoordinatorToolServer:
                 ephemeral one instead of failing. The fallback logs a warning
                 because a URL allowlist written for the fixed port will not
                 match it.
+
+        Raises:
+            ValueError: ``host`` is not a loopback address.
         """
+        if not _is_loopback(host):
+            raise ValueError(f"host must be a loopback address; got {host!r}")
         self._host = host
         self._requested_port = port
         self._fallback = fallback_to_ephemeral
@@ -267,9 +289,7 @@ class CoordinatorToolServer:
         self._server: uvicorn.Server | None = None
         self._serve_task: asyncio.Task[None] | None = None
         self._bound_port: int | None = None
-        self._allowed_hostnames: frozenset[str] = frozenset(
-            {host.lower(), "localhost", "127.0.0.1", "::1"},
-        )
+        self._allowed_hostnames: frozenset[str] = frozenset({host.lower()}) | _LOOPBACK_ALIASES
 
     # ── Lifecycle ──
 
@@ -283,6 +303,8 @@ class CoordinatorToolServer:
         Raises:
             OSError: The fixed port is taken and ``fallback_to_ephemeral``
                 is false.
+            TimeoutError: Serving did not come up within
+                :data:`_STARTUP_TIMEOUT` seconds.
 
         Concurrency:
             Idempotent; a started server ignores further ``start`` calls.
@@ -304,14 +326,24 @@ class CoordinatorToolServer:
         )
         self._server = uvicorn.Server(config)
         self._serve_task = asyncio.create_task(self._server.serve(sockets=[sock]))
+        deadline = asyncio.get_running_loop().time() + _STARTUP_TIMEOUT
         while not self._server.started:
             if self._serve_task.done():
                 self._serve_task.result()  # surface the startup failure
                 raise RuntimeError("tool server exited before startup completed")
+            if asyncio.get_running_loop().time() >= deadline:
+                await self.stop()
+                raise TimeoutError(
+                    f"tool server did not start within {_STARTUP_TIMEOUT}s",
+                )
             await asyncio.sleep(0.01)
 
     async def stop(self) -> None:
         """Stop serving and revoke every registration.
+
+        In-flight tool calls are dropped rather than drained: a client waiting
+        on one (``send_message(mode="wait")``, say) sees the connection close
+        mid-response.
 
         Concurrency:
             Idempotent; stopping a never-started server is a no-op.
@@ -377,7 +409,10 @@ class CoordinatorToolServer:
         return ToolServerRegistration(url=f"{self.base_url}/mcp/{token}", token=token)
 
     def deregister(self, thread_id: ThreadId) -> None:
-        """Revoke ``thread_id``'s token; requests with it fail immediately.
+        """Revoke ``thread_id``'s token; later requests with it 404.
+
+        A request already dispatched keeps the registration it resolved for the
+        rest of its lifetime; revocation is not a cancellation.
 
         Concurrency:
             Idempotent; deregistering an unknown thread is a no-op.

--- a/src/ai_functions/runtime/tool_server.py
+++ b/src/ai_functions/runtime/tool_server.py
@@ -15,19 +15,19 @@ URL::
     server = CoordinatorToolServer()
     await server.start()
     reg = server.register(coordinator, thread_id)
-    # reg.url  -> http://127.0.0.1:8787/mcp/<token>
+    # reg.url  -> http://127.0.0.1:<port>/mcp/<token>
     # reg.token, for transports that pass the secret out of band
     ...
     server.deregister(thread_id)
     await server.stop()
 
-Security model: the port is reachable by any local process, so the
-*token* is the boundary. Each registration mints a ``secrets``-grade token
-that must appear both in the URL path and in the ``Authorization: Bearer``
-header (constant-time compared); the ``Host`` header must name the bound host or
-a loopback alias (DNS-rebinding defense per the MCP spec's guidance for local
-HTTP servers); deregistration revokes the token immediately. The bind host is
-loopback.
+The server binds 127.0.0.1 on a system-assigned port; pass ``reg.url`` to the
+runtime as it starts. The port is reachable by any local process, so the *token*
+is the boundary: each registration mints a ``secrets``-grade token that must
+appear both in the URL path and in the ``Authorization: Bearer`` header
+(constant-time compared), the ``Host`` header must name the bound address
+(DNS-rebinding defense per the MCP spec's guidance for local HTTP servers), and
+deregistration revokes the token immediately.
 
 The MCP app runs stateless (``stateless_http=True``): tools and one-shot
 reads only — no server-initiated messages, no resource subscriptions.
@@ -40,10 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
-import errno
 import hmac
-import ipaddress
-import logging
 import secrets
 import socket
 from collections.abc import Awaitable, Callable, MutableMapping
@@ -70,27 +67,11 @@ except ImportError as exc:  # pragma: no cover - exercised only without the extr
         "    pip install 'strands-ai-functions[runtime-tools]'",
     ) from exc
 
-logger = logging.getLogger(__name__)
-
-DEFAULT_PORT = 8787
-"""Default fixed port. Fixed (not ephemeral) by design: MCP URL allowlists
-(e.g. Claude Code's ``allowedMcpServers``) match on URL patterns that must be
-written before the server exists, so one glob like ``http://127.0.0.1:8787/*``
-can cover every thread for the deployment's lifetime."""
+_HOST = "127.0.0.1"
+"""Bind address, and the only ``Host`` header the server answers to."""
 
 _STARTUP_TIMEOUT = 10.0
 """Seconds to wait for uvicorn to report ``started`` before giving up."""
-
-_LOOPBACK_ALIASES = frozenset({"localhost", "127.0.0.1", "::1"})
-"""Names a loopback-bound server also answers to."""
-
-
-def _is_loopback(host: str) -> bool:
-    """Whether ``host`` names the loopback interface."""
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        return host.lower() == "localhost"
 
 
 # ASGI shorthands (plain dicts/callables; no framework import needed).
@@ -226,11 +207,12 @@ class _TokenRouter:
         finally:
             _active_registration.reset(ctx_token)
 
-    def _host_allowed(self, scope: _Scope) -> bool:
+    @staticmethod
+    def _host_allowed(scope: _Scope) -> bool:
         """Accept only Host headers naming the bound host (DNS-rebinding defense)."""
         raw = dict(scope.get("headers") or []).get(b"host", b"")
         hostname = raw.decode("latin-1").rsplit(":", 1)[0].strip("[]").lower()
-        return hostname in self._server._allowed_hostnames  # pyright: ignore[reportPrivateUsage]  # module-internal
+        return hostname == _HOST
 
     @staticmethod
     def _bearer(scope: _Scope) -> str | None:
@@ -257,39 +239,13 @@ class CoordinatorToolServer:
         each other's registration.
     """
 
-    def __init__(
-        self,
-        *,
-        host: str = "127.0.0.1",
-        port: int = DEFAULT_PORT,
-        fallback_to_ephemeral: bool = True,
-    ) -> None:
-        """Configure the server; nothing binds until :meth:`start`.
-
-        Args:
-            host: Loopback interface to bind.
-            port: Fixed port to bind. Fixed by design — see
-                :data:`DEFAULT_PORT`. ``0`` requests an ephemeral port
-                outright.
-            fallback_to_ephemeral: When the fixed port is taken, bind an
-                ephemeral one instead of failing. The fallback logs a warning
-                because a URL allowlist written for the fixed port will not
-                match it.
-
-        Raises:
-            ValueError: ``host`` is not a loopback address.
-        """
-        if not _is_loopback(host):
-            raise ValueError(f"host must be a loopback address; got {host!r}")
-        self._host = host
-        self._requested_port = port
-        self._fallback = fallback_to_ephemeral
+    def __init__(self) -> None:
+        """Configure the server; nothing binds until :meth:`start`."""
         self._registrations: dict[str, _Registration] = {}
         self._by_thread: dict[ThreadId, str] = {}
         self._server: uvicorn.Server | None = None
         self._serve_task: asyncio.Task[None] | None = None
         self._bound_port: int | None = None
-        self._allowed_hostnames: frozenset[str] = frozenset({host.lower()}) | _LOOPBACK_ALIASES
 
     # ── Lifecycle ──
 
@@ -301,8 +257,6 @@ class CoordinatorToolServer:
             - Requests are answered (all-404 until a thread registers).
 
         Raises:
-            OSError: The fixed port is taken and ``fallback_to_ephemeral``
-                is false.
             TimeoutError: Serving did not come up within
                 :data:`_STARTUP_TIMEOUT` seconds.
 
@@ -319,7 +273,7 @@ class CoordinatorToolServer:
         app = _TokenRouter(_build_mcp_app().streamable_http_app(), self)
         config = uvicorn.Config(
             app,
-            host=self._host,
+            host=_HOST,
             port=bound_port,
             log_level="warning",
             lifespan="on",
@@ -368,12 +322,7 @@ class CoordinatorToolServer:
         """
         if self._bound_port is None:
             raise RuntimeError("CoordinatorToolServer is not started")
-        return f"http://{self._host}:{self._bound_port}"
-
-    @property
-    def port(self) -> int | None:
-        """The bound port while running, else ``None``."""
-        return self._bound_port
+        return f"http://{_HOST}:{self._bound_port}"
 
     # ── Registrations ──
 
@@ -427,26 +376,12 @@ class CoordinatorToolServer:
         """Resolve a path token to its registration; ``None`` when revoked/unknown."""
         return self._registrations.get(token)
 
-    def _bind_socket(self) -> socket.socket:
-        """Bind the listening socket, honouring the ephemeral fallback."""
+    @staticmethod
+    def _bind_socket() -> socket.socket:
+        """Bind the listening socket on a system-assigned port."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            return self._bind(self._requested_port)
-        except OSError as exc:
-            if exc.errno != errno.EADDRINUSE or not self._fallback or self._requested_port == 0:
-                raise
-            logger.warning(
-                "tool server port %d is in use; falling back to an ephemeral port — "
-                "URL allowlists written for the fixed port will not match",
-                self._requested_port,
-            )
-            return self._bind(0)
-
-    def _bind(self, port: int) -> socket.socket:
-        family = socket.AF_INET6 if ":" in self._host else socket.AF_INET
-        sock = socket.socket(family, socket.SOCK_STREAM)
-        try:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind((self._host, port))
+            sock.bind((_HOST, 0))
             sock.listen(2048)
             sock.setblocking(False)
         except BaseException:

--- a/src/ai_functions/runtime/tool_server.py
+++ b/src/ai_functions/runtime/tool_server.py
@@ -1,0 +1,420 @@
+"""``CoordinatorToolServer`` — the runtime tools over streamable-HTTP MCP.
+
+Serves the two coordinator tools from
+:mod:`ai_functions.runtime.coordinator_tools_core` (``list_threads`` /
+``send_message``) to any MCP-speaking agent runtime over HTTP, so foreign
+backends that cannot host an in-process MCP server (Codex, Kiro, anything
+else with an ``mcp_servers`` config) can join a team without per-runtime
+bridge code.
+
+One server per worker. Each thread registers to receive its own capability
+URL::
+
+    server = CoordinatorToolServer()
+    await server.start()
+    reg = server.register(coordinator, thread_id)
+    # reg.url  -> http://127.0.0.1:8787/mcp/<token>
+    # reg.token, for transports that pass the secret out of band
+    ...
+    server.deregister(thread_id)
+    await server.stop()
+
+Security model: the port is reachable by any local process, so the
+*token* is the boundary. Each registration mints a ``secrets``-grade token
+that must appear both in the URL path and in the ``Authorization: Bearer``
+header (constant-time compared); the ``Host`` header must resolve to the
+bound host (DNS-rebinding defense per the MCP spec's guidance for local
+HTTP servers); deregistration revokes the token immediately.
+
+The MCP app runs stateless (``stateless_http=True``): tools and one-shot
+reads only — no server-initiated messages, no resource subscriptions.
+Session state lives in the coordinator, not the transport.
+
+Requires the ``runtime-tools`` extra (``mcp``, ``uvicorn``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import errno
+import hmac
+import logging
+import secrets
+import socket
+from collections.abc import Awaitable, Callable, MutableMapping
+from dataclasses import dataclass
+from typing import Any, final
+
+from ..protocols import Coordinator
+from ..types import ThreadId
+from .coordinator_tools_core import (
+    LIST_THREADS_DESCRIPTION,
+    SEND_MESSAGE_DESCRIPTION,
+    SendMessageMode,
+)
+from .coordinator_tools_core import list_threads as _core_list_threads
+from .coordinator_tools_core import send_message as _core_send_message
+
+try:
+    import uvicorn
+    from mcp.server.fastmcp import FastMCP
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    raise ImportError(
+        "CoordinatorToolServer requires the optional 'runtime-tools' extra "
+        "(the MCP server and an ASGI server). Install it with:\n"
+        "    pip install 'strands-ai-functions[runtime-tools]'",
+    ) from exc
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PORT = 8787
+"""Default fixed port. Fixed (not ephemeral) by design: MCP URL allowlists
+(e.g. Claude Code's ``allowedMcpServers``) match on URL patterns that must be
+written before the server exists, so one glob like ``http://127.0.0.1:8787/*``
+can cover every thread for the deployment's lifetime."""
+
+# ASGI shorthands (plain dicts/callables; no framework import needed).
+_Scope = MutableMapping[str, Any]  # pyright: ignore[reportExplicitAny]
+_Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]  # pyright: ignore[reportExplicitAny]
+_Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]  # pyright: ignore[reportExplicitAny]
+
+
+@dataclass(frozen=True)
+class ToolServerRegistration:
+    """One thread's capability to call the runtime tools."""
+
+    url: str
+    """Full MCP endpoint for this thread, token embedded in the path."""
+
+    token: str
+    """The bare secret, for transports that pass it out of band (e.g. Codex's
+    ``bearer_token_env_var``). Required in the ``Authorization: Bearer`` header
+    on every request."""
+
+
+@dataclass(frozen=True)
+class _Registration:
+    """Server-side binding of a token to the thread it acts as."""
+
+    coordinator: Coordinator
+    thread_id: ThreadId
+    token: str
+
+
+_active_registration: contextvars.ContextVar[_Registration | None] = contextvars.ContextVar(
+    "ai_functions_tool_server_registration",
+    default=None,
+)
+
+
+def _require_registration() -> _Registration:
+    """Return the request's registration; the router guarantees one is set."""
+    reg = _active_registration.get()
+    if reg is None:  # pragma: no cover - unreachable behind the router
+        raise RuntimeError("tool invoked outside an authenticated request")
+    return reg
+
+
+def _build_mcp_app() -> FastMCP:
+    """Build the single stateless FastMCP app serving both runtime tools.
+
+    Tool identity is per-request: the token router resolves which thread is
+    calling and parks its registration in a context variable before handing
+    the request to this app.
+    """
+    mcp = FastMCP("ai_functions_runtime", stateless_http=True)
+
+    @mcp.tool(name="list_threads", description=LIST_THREADS_DESCRIPTION)
+    async def list_threads() -> str:
+        reg = _require_registration()
+        result = await _core_list_threads(reg.coordinator, str(reg.thread_id))
+        return result.model_dump_json()
+
+    @mcp.tool(name="send_message", description=SEND_MESSAGE_DESCRIPTION)
+    async def send_message(
+        thread_id: str,
+        message: str,
+        mode: SendMessageMode = "wait",
+    ) -> str:
+        reg = _require_registration()
+        return await _core_send_message(reg.coordinator, str(reg.thread_id), thread_id, message, mode)
+
+    return mcp
+
+
+async def _plain_response(send: _Send, status: int, body: str) -> None:
+    """Emit a minimal text/plain ASGI response."""
+    payload = body.encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"content-length", str(len(payload)).encode()),
+            ],
+        },
+    )
+    await send({"type": "http.response.body", "body": payload})
+
+
+@final
+class _TokenRouter:
+    """Pure-ASGI wrapper enforcing the token and Host checks per request.
+
+    Wraps the FastMCP app rather than subclassing any framework middleware so
+    the inner app's lifespan passes through untouched (the streamable-HTTP
+    session manager initialises in the lifespan; dropping it breaks every
+    request).
+    """
+
+    def __init__(self, app: Callable[..., Awaitable[None]], server: CoordinatorToolServer) -> None:
+        self._app = app
+        self._server = server
+
+    async def __call__(self, scope: _Scope, receive: _Receive, send: _Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        if not self._host_allowed(scope):
+            await _plain_response(send, 403, "forbidden: unrecognized Host")
+            return
+
+        path = str(scope.get("path", ""))
+        prefix = "/mcp/"
+        if not path.startswith(prefix):
+            await _plain_response(send, 404, "not found")
+            return
+        token, _, rest = path[len(prefix) :].partition("/")
+
+        registration = self._server._lookup(token)  # pyright: ignore[reportPrivateUsage]  # module-internal
+        if registration is None:
+            await _plain_response(send, 404, "not found")
+            return
+
+        bearer = self._bearer(scope)
+        if bearer is None or not hmac.compare_digest(bearer, registration.token):
+            await _plain_response(send, 401, "unauthorized")
+            return
+
+        # Rewrite to the path the FastMCP app is mounted on.
+        scope["path"] = "/mcp" + (f"/{rest}" if rest else "")
+        ctx_token = _active_registration.set(registration)
+        try:
+            await self._app(scope, receive, send)
+        finally:
+            _active_registration.reset(ctx_token)
+
+    def _host_allowed(self, scope: _Scope) -> bool:
+        """Accept only Host headers naming the bound host (DNS-rebinding defense)."""
+        raw = dict(scope.get("headers") or []).get(b"host", b"")
+        hostname = raw.decode("latin-1").rsplit(":", 1)[0].strip("[]").lower()
+        return hostname in self._server._allowed_hostnames  # pyright: ignore[reportPrivateUsage]  # module-internal
+
+    @staticmethod
+    def _bearer(scope: _Scope) -> str | None:
+        raw = dict(scope.get("headers") or []).get(b"authorization", b"").decode("latin-1")
+        scheme, _, value = raw.partition(" ")
+        if scheme.lower() != "bearer" or not value:
+            return None
+        return value.strip()
+
+
+@final
+class CoordinatorToolServer:
+    """One streamable-HTTP MCP server hosting the runtime tools for a worker.
+
+    Lifecycle:
+        constructed → ``start()`` (binds and serves) → ``register`` /
+        ``deregister`` per thread → ``stop()``.
+
+    Concurrency:
+        ``start``/``stop`` are owned by the hosting worker's event loop.
+        ``register``/``deregister`` are synchronous dict operations, safe to
+        call between requests; per-request identity travels in a context
+        variable, so concurrent requests for different threads never observe
+        each other's registration.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str = "127.0.0.1",
+        port: int = DEFAULT_PORT,
+        fallback_to_ephemeral: bool = True,
+    ) -> None:
+        """Configure the server; nothing binds until :meth:`start`.
+
+        Args:
+            host: Interface to bind. The default serves local agent
+                subprocesses only; binding wider is the caller's decision and
+                should come with real network auth in front.
+            port: Fixed port to bind. Fixed by design — see
+                :data:`DEFAULT_PORT`. ``0`` requests an ephemeral port
+                outright.
+            fallback_to_ephemeral: When the fixed port is taken, bind an
+                ephemeral one instead of failing. The fallback logs a warning
+                because a URL allowlist written for the fixed port will not
+                match it.
+        """
+        self._host = host
+        self._requested_port = port
+        self._fallback = fallback_to_ephemeral
+        self._registrations: dict[str, _Registration] = {}
+        self._by_thread: dict[ThreadId, str] = {}
+        self._server: uvicorn.Server | None = None
+        self._serve_task: asyncio.Task[None] | None = None
+        self._bound_port: int | None = None
+        self._allowed_hostnames: frozenset[str] = frozenset(
+            {host.lower(), "localhost", "127.0.0.1", "::1"},
+        )
+
+    # ── Lifecycle ──
+
+    async def start(self) -> None:
+        """Bind the socket and serve until :meth:`stop`.
+
+        Ensures:
+            - :attr:`base_url` is valid once this returns.
+            - Requests are answered (all-404 until a thread registers).
+
+        Raises:
+            OSError: The fixed port is taken and ``fallback_to_ephemeral``
+                is false.
+
+        Concurrency:
+            Idempotent; a started server ignores further ``start`` calls.
+        """
+        if self._server is not None:
+            return
+
+        sock = self._bind_socket()
+        bound_port = int(sock.getsockname()[1])
+        self._bound_port = bound_port
+
+        app = _TokenRouter(_build_mcp_app().streamable_http_app(), self)
+        config = uvicorn.Config(
+            app,
+            host=self._host,
+            port=bound_port,
+            log_level="warning",
+            lifespan="on",
+        )
+        self._server = uvicorn.Server(config)
+        self._serve_task = asyncio.create_task(self._server.serve(sockets=[sock]))
+        while not self._server.started:
+            if self._serve_task.done():
+                self._serve_task.result()  # surface the startup failure
+                raise RuntimeError("tool server exited before startup completed")
+            await asyncio.sleep(0.01)
+
+    async def stop(self) -> None:
+        """Stop serving and revoke every registration.
+
+        Concurrency:
+            Idempotent; stopping a never-started server is a no-op.
+        """
+        self._registrations.clear()
+        self._by_thread.clear()
+        server, task = self._server, self._serve_task
+        self._server = None
+        self._serve_task = None
+        self._bound_port = None
+        if server is None or task is None:
+            return
+        server.should_exit = True
+        await task
+
+    @property
+    def base_url(self) -> str:
+        """Root URL of the running server (no token).
+
+        Raises:
+            RuntimeError: The server is not started.
+        """
+        if self._bound_port is None:
+            raise RuntimeError("CoordinatorToolServer is not started")
+        return f"http://{self._host}:{self._bound_port}"
+
+    @property
+    def port(self) -> int | None:
+        """The bound port while running, else ``None``."""
+        return self._bound_port
+
+    # ── Registrations ──
+
+    def register(self, coordinator: Coordinator, thread_id: ThreadId) -> ToolServerRegistration:
+        """Mint a capability URL through which ``thread_id`` calls the tools.
+
+        Re-registering a thread revokes its previous token and mints a fresh
+        one.
+
+        Args:
+            coordinator: Coordinator the tools act on for this thread.
+            thread_id: Identity the tools act *as* — ``is_self`` marking,
+                ``send_message`` sender, and the reply target of
+                ``continue_then_receive``.
+
+        Returns:
+            The registration; hand ``url`` (and, for out-of-band transports,
+            ``token``) to the agent runtime's MCP config.
+
+        Raises:
+            RuntimeError: The server is not started.
+        """
+        if self._bound_port is None:
+            raise RuntimeError("CoordinatorToolServer is not started; call start() first")
+        self.deregister(thread_id)
+        token = secrets.token_urlsafe(32)
+        self._registrations[token] = _Registration(
+            coordinator=coordinator,
+            thread_id=thread_id,
+            token=token,
+        )
+        self._by_thread[thread_id] = token
+        return ToolServerRegistration(url=f"{self.base_url}/mcp/{token}", token=token)
+
+    def deregister(self, thread_id: ThreadId) -> None:
+        """Revoke ``thread_id``'s token; requests with it fail immediately.
+
+        Concurrency:
+            Idempotent; deregistering an unknown thread is a no-op.
+        """
+        token = self._by_thread.pop(thread_id, None)
+        if token is not None:
+            _ = self._registrations.pop(token, None)
+
+    # ── Internals ──
+
+    def _lookup(self, token: str) -> _Registration | None:
+        """Resolve a path token to its registration; ``None`` when revoked/unknown."""
+        return self._registrations.get(token)
+
+    def _bind_socket(self) -> socket.socket:
+        """Bind the listening socket, honouring the ephemeral fallback."""
+        try:
+            return self._bind(self._requested_port)
+        except OSError as exc:
+            if exc.errno != errno.EADDRINUSE or not self._fallback or self._requested_port == 0:
+                raise
+            logger.warning(
+                "tool server port %d is in use; falling back to an ephemeral port — "
+                "URL allowlists written for the fixed port will not match",
+                self._requested_port,
+            )
+            return self._bind(0)
+
+    def _bind(self, port: int) -> socket.socket:
+        family = socket.AF_INET6 if ":" in self._host else socket.AF_INET
+        sock = socket.socket(family, socket.SOCK_STREAM)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind((self._host, port))
+            sock.listen(2048)
+            sock.setblocking(False)
+        except BaseException:
+            sock.close()
+            raise
+        return sock

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -78,9 +78,6 @@ ai_functions.optimizer.textgrad.logger
 ai_functions.memory.agentcore_backend.logger
 ai_functions.memory.base.logger
 
-# Tool server module logger is internal implementation detail.
-ai_functions.runtime.tool_server.logger
-
 # economics: module-level loggers are private implementation detail
 ai_functions.experimental.economics.beliefs.logger
 ai_functions.experimental.economics.function.logger

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -78,6 +78,9 @@ ai_functions.optimizer.textgrad.logger
 ai_functions.memory.agentcore_backend.logger
 ai_functions.memory.base.logger
 
+# Tool server module logger is internal implementation detail.
+ai_functions.runtime.tool_server.logger
+
 # economics: module-level loggers are private implementation detail
 ai_functions.experimental.economics.beliefs.logger
 ai_functions.experimental.economics.function.logger

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -233,6 +233,12 @@ async def test_fixed_port_without_fallback_raises() -> None:
         blocker.close()
 
 
+async def test_non_loopback_host_is_rejected() -> None:
+    """A non-loopback bind is refused at construction."""
+    with pytest.raises(ValueError, match="loopback"):
+        CoordinatorToolServer(host="0.0.0.0", port=0)
+
+
 async def test_register_before_start_raises() -> None:
     """A registration needs a bound port to mint a URL."""
     srv = CoordinatorToolServer(port=0)

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -1,0 +1,249 @@
+"""``CoordinatorToolServer`` — HTTP MCP access to the runtime tools.
+
+Hermetic: a stub coordinator and the ``mcp`` Python client, no agent binary
+and no model. Pins the contract foreign runtimes rely on: tool schemas match
+the shared core's declaration, per-thread tokens isolate identity, auth is
+required in both the path and the header, and revocation is immediate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any
+
+import httpx
+import pytest
+
+pytest.importorskip("mcp")
+pytest.importorskip("uvicorn")
+
+from mcp import ClientSession  # noqa: E402
+from mcp.client.streamable_http import streamable_http_client  # noqa: E402
+
+from ai_functions.runtime.coordinator_tools_core import SEND_MESSAGE_INPUT_SCHEMA  # noqa: E402
+from ai_functions.runtime.tool_server import CoordinatorToolServer  # noqa: E402
+from ai_functions.types import InputShape, ThreadId, ThreadInfo, ThreadStatus, WorkerId  # noqa: E402
+
+
+def _info(thread_id: str, name: str) -> ThreadInfo:
+    return ThreadInfo(
+        thread_id=ThreadId(thread_id),
+        worker_id=WorkerId("w-1"),
+        thread_name=name,
+        input_shape=InputShape.STR_PROMPT,
+        status=ThreadStatus.IDLE,
+    )
+
+
+class _Handle:
+    """Peer handle whose run() resolves immediately with a canned reply."""
+
+    def __init__(self, reply: str) -> None:
+        self._reply = reply
+
+    def run(self, message: str) -> asyncio.Future[str]:
+        fut: asyncio.Future[str] = asyncio.get_event_loop().create_future()
+        fut.set_result(f"{self._reply}:{message}")
+        return fut
+
+
+class _StubCoordinator:
+    """Just enough Coordinator for the two tools: registry + handles."""
+
+    def __init__(self) -> None:
+        self.infos = {
+            ThreadId("t-alice"): _info("t-alice", "alice"),
+            ThreadId("t-bob"): _info("t-bob", "bob"),
+        }
+
+    async def list_threads(self) -> list[ThreadInfo]:
+        return list(self.infos.values())
+
+    async def get_thread_info(self, thread_id: ThreadId) -> ThreadInfo:
+        return self.infos[thread_id]
+
+    def get_handle(self, thread_id: ThreadId) -> _Handle:
+        return _Handle("pong")
+
+
+def _http(token: str) -> httpx.AsyncClient:
+    """An httpx client carrying the bearer header on every request."""
+    return httpx.AsyncClient(headers={"Authorization": f"Bearer {token}"})
+
+
+async def _call(url: str, token: str, tool: str, args: dict[str, Any]) -> str:  # pyright: ignore[reportExplicitAny]
+    """Open a session against ``url`` and invoke one tool."""
+    async with streamable_http_client(url, http_client=_http(token)) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(tool, args)
+            block = result.content[0]
+            assert block.type == "text"
+            return block.text
+
+
+@pytest.fixture
+async def server():  # noqa: ANN201 - pytest fixture
+    srv = CoordinatorToolServer(port=0)
+    await srv.start()
+    yield srv
+    await srv.stop()
+
+
+async def test_tools_and_schema_match_the_shared_core(server: CoordinatorToolServer) -> None:
+    """The wire schema is the shared declaration: enum, default, required."""
+    reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    async with streamable_http_client(reg.url, http_client=_http(reg.token)) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = {t.name: t for t in (await session.list_tools()).tools}
+
+    assert set(tools) == {"list_threads", "send_message"}
+    schema = tools["send_message"].inputSchema
+    core = SEND_MESSAGE_INPUT_SCHEMA["properties"]
+    assert schema["properties"]["mode"]["enum"] == core["mode"]["enum"]
+    assert schema["properties"]["mode"]["default"] == core["mode"]["default"]
+    assert schema["required"] == SEND_MESSAGE_INPUT_SCHEMA["required"]
+
+
+async def test_each_registration_acts_as_its_own_thread(server: CoordinatorToolServer) -> None:
+    """Two tokens on one server resolve to distinct calling identities."""
+    coord = _StubCoordinator()
+    alice = server.register(coord, ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    bob = server.register(coord, ThreadId("t-bob"))  # pyright: ignore[reportArgumentType]
+
+    import json
+
+    as_alice = json.loads(await _call(alice.url, alice.token, "list_threads", {}))
+    as_bob = json.loads(await _call(bob.url, bob.token, "list_threads", {}))
+    self_of = lambda payload: next(t["thread_name"] for t in payload["threads"] if t["is_self"])  # noqa: E731
+    assert self_of(as_alice) == "alice"
+    assert self_of(as_bob) == "bob"
+
+
+async def test_send_message_dispatches_to_the_peer(server: CoordinatorToolServer) -> None:
+    """A wait-mode send returns the peer's reply through the tool result."""
+    reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    reply = await _call(reg.url, reg.token, "send_message", {"thread_id": "t-bob", "message": "ping"})
+    assert "pong:ping" in reply
+
+
+async def test_tools_work_with_no_cycle_in_flight(server: CoordinatorToolServer) -> None:
+    """Identity comes from the token, not a live cycle context.
+
+    The in-process SDK transport answers ``error: no active cycle`` between
+    cycles; over HTTP an idle thread's peers can still discover and message it.
+    """
+    reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    # No worker, no dispatcher, no ThreadContext anywhere in this test.
+    text = await _call(reg.url, reg.token, "list_threads", {})
+    assert '"is_self":true' in text.replace(" ", "")
+
+
+async def test_header_token_is_required(server: CoordinatorToolServer) -> None:
+    """The path token alone is not enough; the bearer header must match it."""
+    coord = _StubCoordinator()
+    alice = server.register(coord, ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    bob = server.register(coord, ThreadId("t-bob"))  # pyright: ignore[reportArgumentType]
+
+    async with httpx.AsyncClient() as client:
+        # No Authorization header at all.
+        r = await client.post(alice.url, json={})
+        assert r.status_code == 401
+        # A *valid* token for a different thread in the header.
+        r = await client.post(bob.url, json={}, headers={"Authorization": f"Bearer {alice.token}"})
+        assert r.status_code == 401
+
+
+async def test_unknown_token_is_not_found(server: CoordinatorToolServer) -> None:
+    """A fabricated path token is rejected before any tool logic runs."""
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            f"{server.base_url}/mcp/not-a-real-token",
+            json={},
+            headers={"Authorization": "Bearer not-a-real-token"},
+        )
+        assert r.status_code == 404
+
+
+async def test_deregister_revokes_immediately(server: CoordinatorToolServer) -> None:
+    """A revoked token stops working without a server restart."""
+    reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    assert "pong" in await _call(reg.url, reg.token, "send_message", {"thread_id": "t-bob", "message": "x"})
+    server.deregister(ThreadId("t-alice"))
+    async with httpx.AsyncClient() as client:
+        r = await client.post(reg.url, json={}, headers={"Authorization": f"Bearer {reg.token}"})
+        assert r.status_code == 404
+
+
+async def test_reregister_rotates_the_token(server: CoordinatorToolServer) -> None:
+    """Registering the same thread again revokes the old token."""
+    coord = _StubCoordinator()
+    first = server.register(coord, ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    second = server.register(coord, ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    assert first.token != second.token
+    async with httpx.AsyncClient() as client:
+        r = await client.post(first.url, json={}, headers={"Authorization": f"Bearer {first.token}"})
+        assert r.status_code == 404
+    assert "pong" in await _call(second.url, second.token, "send_message", {"thread_id": "t-bob", "message": "x"})
+
+
+async def test_unrecognized_host_is_rejected(server: CoordinatorToolServer) -> None:
+    """A Host header naming a foreign origin is refused (DNS-rebinding defense)."""
+    reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            reg.url,
+            json={},
+            headers={"Authorization": f"Bearer {reg.token}", "Host": "evil.example.com"},
+        )
+        assert r.status_code == 403
+
+
+async def test_fixed_port_falls_back_to_ephemeral_when_taken() -> None:
+    """A taken fixed port falls back to an ephemeral bind with a warning."""
+    blocker = socket.socket()
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen(1)
+    taken_port = blocker.getsockname()[1]
+    try:
+        srv = CoordinatorToolServer(port=taken_port, fallback_to_ephemeral=True)
+        await srv.start()
+        try:
+            assert srv.port is not None
+            assert srv.port != taken_port
+        finally:
+            await srv.stop()
+    finally:
+        blocker.close()
+
+
+async def test_fixed_port_without_fallback_raises() -> None:
+    """fallback_to_ephemeral=False turns a taken port into a hard error."""
+    blocker = socket.socket()
+    blocker.bind(("127.0.0.1", 0))
+    blocker.listen(1)
+    taken_port = blocker.getsockname()[1]
+    try:
+        srv = CoordinatorToolServer(port=taken_port, fallback_to_ephemeral=False)
+        with pytest.raises(OSError):
+            await srv.start()
+    finally:
+        blocker.close()
+
+
+async def test_register_before_start_raises() -> None:
+    """A registration needs a bound port to mint a URL."""
+    srv = CoordinatorToolServer(port=0)
+    with pytest.raises(RuntimeError):
+        srv.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+
+
+async def test_stop_is_idempotent() -> None:
+    """Stopping twice (or before starting) is a no-op."""
+    srv = CoordinatorToolServer(port=0)
+    await srv.stop()
+    await srv.start()
+    await srv.stop()
+    await srv.stop()

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -9,7 +9,6 @@ required in both the path and the header, and revocation is immediate.
 from __future__ import annotations
 
 import asyncio
-import socket
 from typing import Any
 
 import httpx
@@ -85,7 +84,7 @@ async def _call(url: str, token: str, tool: str, args: dict[str, Any]) -> str:  
 
 @pytest.fixture
 async def server():  # noqa: ANN201 - pytest fixture
-    srv = CoordinatorToolServer(port=0)
+    srv = CoordinatorToolServer()
     await srv.start()
     yield srv
     await srv.stop()
@@ -201,54 +200,16 @@ async def test_unrecognized_host_is_rejected(server: CoordinatorToolServer) -> N
         assert r.status_code == 403
 
 
-async def test_fixed_port_falls_back_to_ephemeral_when_taken() -> None:
-    """A taken fixed port falls back to an ephemeral bind with a warning."""
-    blocker = socket.socket()
-    blocker.bind(("127.0.0.1", 0))
-    blocker.listen(1)
-    taken_port = blocker.getsockname()[1]
-    try:
-        srv = CoordinatorToolServer(port=taken_port, fallback_to_ephemeral=True)
-        await srv.start()
-        try:
-            assert srv.port is not None
-            assert srv.port != taken_port
-        finally:
-            await srv.stop()
-    finally:
-        blocker.close()
-
-
-async def test_fixed_port_without_fallback_raises() -> None:
-    """fallback_to_ephemeral=False turns a taken port into a hard error."""
-    blocker = socket.socket()
-    blocker.bind(("127.0.0.1", 0))
-    blocker.listen(1)
-    taken_port = blocker.getsockname()[1]
-    try:
-        srv = CoordinatorToolServer(port=taken_port, fallback_to_ephemeral=False)
-        with pytest.raises(OSError):
-            await srv.start()
-    finally:
-        blocker.close()
-
-
-async def test_non_loopback_host_is_rejected() -> None:
-    """A non-loopback bind is refused at construction."""
-    with pytest.raises(ValueError, match="loopback"):
-        CoordinatorToolServer(host="0.0.0.0", port=0)
-
-
 async def test_register_before_start_raises() -> None:
     """A registration needs a bound port to mint a URL."""
-    srv = CoordinatorToolServer(port=0)
+    srv = CoordinatorToolServer()
     with pytest.raises(RuntimeError):
         srv.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
 
 
 async def test_stop_is_idempotent() -> None:
     """Stopping twice (or before starting) is a no-op."""
-    srv = CoordinatorToolServer(port=0)
+    srv = CoordinatorToolServer()
     await srv.stop()
     await srv.start()
     await srv.stop()


### PR DESCRIPTION
Rebased on `main`. #35 and #36 have merged, so their commits are out of this diff — what is left is the tool server plus @alexachille's two follow-ups, unchanged (`git range-diff` confirms all three commits are identical across the rebase). #38 sits on top and will rebase once this lands.

## What this is

`list_threads` / `send_message` (from the shared core in `runtime/coordinator_tools_core.py`) served over **stateless streamable-HTTP MCP**, so any MCP-speaking runtime joins a team without per-runtime bridge code. The in-process SDK server in `claude_code/` is proprietary to `claude-agent-sdk`; this is the transport for everything else — Codex (`mcp_servers.<name>.url` + `bearer_token_env_var`, probed working end-to-end against a live Codex session), Kiro/ACP (`HttpMcpServer`), and anything with an MCP config. Claude keeps its in-process transport: enterprise `allowedMcpServers` URL allowlists apply to HTTP servers but not SDK ones (observed live), so moving it would regress managed environments.

## Design decisions

**One server per worker, one token per thread.** `register(coordinator, thread_id)` mints a capability URL `http://127.0.0.1:<port>/mcp/<token>`; the token is the security boundary (the port is reachable by any local process). Secrets-grade, required in **both** the path and the `Authorization: Bearer` header (constant-time compared), revoked immediately on `deregister`, rotated on re-register. The `Host` header must equal the bound address — DNS-rebinding defense per the MCP spec's guidance for local HTTP servers.

**Loopback bind, system-assigned port.** `__init__` takes no arguments: the server binds `(127.0.0.1, 0)`. The process that starts the server is the process that launches the runtime and writes its MCP config from `reg.url`, so there is nothing to coordinate ahead of time and no fixed port to collide with. (A deployment that gates MCP by URL allowlist needs a fixed port to write a glob against; that is not the local-Codex path this serves.)

**Identity from the token, not a live cycle.** The in-process transport answers `error: no active cycle` between cycles — exactly when a peer is most likely to be asking. Here, tools work while the thread is idle; a test pins this with no worker, dispatcher, or `ThreadContext` in sight.

**Pure-ASGI token router.** Wrapping (not framework middleware) so the FastMCP app's lifespan — where the streamable-HTTP session manager initialises — passes through intact; `Mount`-style composition drops it and 500s every request. Per-request identity travels in a contextvar, so concurrent requests for different threads never observe each other.

**Stateless.** Tools + one-shot reads only; no server-initiated messages, no resource subscriptions. Push already belongs to the coordinator (`notify`, `continue_then_receive`); MCP is the pull channel.

## Schema parity

The tools bind the same `SendMessageMode` Literal the Strands and Claude adapters use, and a test asserts the wire schema (enum, default, required) matches `SEND_MESSAGE_INPUT_SCHEMA` — the third transport can't drift any more than the first two can.

## Scope

Server + tests only. No agent backend is wired to it here — that's #38 (Codex) and a follow-up for Kiro.

## Verification

Hermetic tests (stub coordinator + the `mcp` Python client — no agent binary, no model): 11 tests covering schema parity, per-token identity isolation, peer dispatch, tools-while-idle, both-places token enforcement, unknown token 404, immediate revocation, token rotation, Host rejection 403, register-before-start, idempotent stop.

Full suite on the rebase: **429 passed / 2 skipped**. `hatch run lint` clean, `ruff format --check` clean, `hatch run check-spec` (stubtest) clean across 77 modules, pyright 0 errors on the module, its stub, and its test. New extra `runtime-tools = ["mcp>=1.29", "uvicorn>=0.30"]` — zero marginal cost next to `claude-code`, which already pulls `mcp`.
