### PR TITLE
feat(codex): CodexAgent / CodexAgentThread — OpenAI Codex backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ runtime-tools = [
 ]
 codex = [
     "openai-codex>=0.144.4",
+    # The Codex thread serves the runtime tools to the app-server over HTTP
+    # MCP (CoordinatorToolServer), so the runtime-tools deps come along.
+    "mcp>=1.29",
+    "uvicorn>=0.30",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ runtime-tools = [
     "mcp>=1.29",
     "uvicorn>=0.30",
 ]
+codex = [
+    "openai-codex>=0.144.4",
+]
 
 [project.scripts]
 ai-functions = "ai_functions.cli:main"
@@ -96,6 +99,7 @@ dependencies = [
     "agent-client-protocol>=0.12.1,<0.13",
     "mcp>=1.29",
     "uvicorn>=0.30",
+    "openai-codex>=0.144.4",
     "pyyaml>=6.0",
     "bedrock-agentcore>=1.6.0",
     "rank-bm25>=0.2.2",
@@ -120,6 +124,9 @@ testpaths = ["tests"]
 pythonpath = ["examples"]
 python_files = ["test_*.py", "*_test.py"]
 asyncio_mode = "auto"
+markers = [
+    "integration: runs a real agent runtime binary (hermetic; model layer mocked)",
+]
 filterwarnings = [
     "ignore:websockets\\.legacy is deprecated:DeprecationWarning:websockets.legacy",
 ]

--- a/spec/ai_functions/codex/__init__.pyi
+++ b/spec/ai_functions/codex/__init__.pyi
@@ -1,0 +1,10 @@
+"""CodexAgentThread — a ``Spawnable``/``Thread`` pair backed by the OpenAI Codex SDK."""
+
+from __future__ import annotations
+
+from .codex import CodexAgent, CodexAgentThread
+
+__all__ = [
+    "CodexAgent",
+    "CodexAgentThread",
+]

--- a/spec/ai_functions/codex/codex.pyi
+++ b/spec/ai_functions/codex/codex.pyi
@@ -20,7 +20,14 @@ Approvals: the public SDK exposes only ``ApprovalMode.auto_review`` /
 ``deny_all`` — there is no human-in-the-loop callback, so approvals are not
 routed through ``ctx.on_interrupt``.
 
-Requires the ``codex`` extra (``openai-codex``, which bundles the runtime).
+Runtime tools: each thread starts its own ``CoordinatorToolServer`` when it
+connects and injects the capability URL (token via the subprocess
+environment) into the app-server launch config, so the Codex agent can call
+``list_threads`` / ``send_message`` over HTTP MCP. ``teardown`` stops the
+server.
+
+Requires the ``codex`` extra (``openai-codex``, which bundles the runtime,
+plus the HTTP MCP server dependencies).
 """
 
 from collections.abc import Hashable, Sequence
@@ -263,6 +270,7 @@ class CodexAgentThread(Thread[[str], str]):
 
         Ensures:
             - Any running ``AsyncCodex`` client is closed.
+            - The runtime tool server is stopped and its token revoked.
             - In-flight steers are cancelled and awaited.
             - Pending inject-buffer entries are dropped.
 

--- a/spec/ai_functions/codex/codex.pyi
+++ b/spec/ai_functions/codex/codex.pyi
@@ -1,0 +1,292 @@
+"""``CodexAgent`` template and ``CodexAgentThread`` — OpenAI Codex-backed thread.
+
+A ``CodexAgentThread`` drives a ``codex app-server`` subprocess through the
+OpenAI Codex Python SDK. The app-server owns the conversation transcript;
+ai_functions observes its notification stream and re-emits each element as a
+ai_functions event — pure observability, not a source of truth. The
+implementation module's docstring carries the full Codex-to-event mapping.
+
+Distinguishing capabilities relative to the Claude and Kiro backends:
+
+- ``fork()`` is real — Codex forks the stored conversation server-side and
+  the returned template resumes the fork.
+- ``notify()`` reaches a *running* turn by steering it, not only the next one.
+- Cooperative cancel interrupts the in-flight turn rather than waiting for
+  the cycle boundary.
+- The template is meaningfully picklable: session identity is a string
+  (``resume_thread_id``).
+
+Approvals: the public SDK exposes only ``ApprovalMode.auto_review`` /
+``deny_all`` — there is no human-in-the-loop callback, so approvals are not
+routed through ``ctx.on_interrupt``.
+
+Requires the ``codex`` extra (``openai-codex``, which bundles the runtime).
+"""
+
+from collections.abc import Hashable, Sequence
+from dataclasses import dataclass
+from typing import final
+
+from openai_codex import ApprovalMode, Sandbox
+from openai_codex.client import CodexConfig
+from openai_codex.generated.v2_all import Personality, ReasoningEffort, ReasoningSummary
+from strands.tools import ToolProvider
+from strands.types.tools import AgentTool
+
+from ..ai_thread.postcondition import PostCondition
+from ..protocols import Spawnable, Thread
+from ..types import InputShape, ThreadContext
+
+@final
+@dataclass(frozen=True)
+class CodexAgent(Spawnable[[str], str], ToolProvider):
+    """Immutable template for an OpenAI-Codex-backed thread.
+
+    Carries the configuration used to launch the ``codex app-server``
+    subprocess and start (or resume) its conversation thread, plus the
+    display metadata needed to expose the resulting thread as a Strands
+    tool. Picklable and safe to share across runtimes: session identity is
+    a string (``resume_thread_id``), so a template can travel to any host
+    that has Codex auth and an equivalent working directory.
+
+    Implements:
+        Spawnable, strands.tools.ToolProvider.
+
+    Immutable: Yes.
+    """
+
+    config: CodexConfig | None = None
+    """Launch configuration forwarded to the SDK client (binary path, cwd,
+    env, config overrides); ``None`` uses the bundled runtime's defaults."""
+
+    model: str | None = None
+    """Model id for the conversation thread; ``None`` uses the Codex default."""
+
+    sandbox: Sandbox | None = None
+    """Filesystem access preset (``read_only`` / ``workspace_write`` /
+    ``full_access``); ``None`` uses the Codex default."""
+
+    approval_mode: ApprovalMode = ...
+    """How escalated permission requests are resolved. ``auto_review`` (the
+    default) lets Codex's own reviewer arbitrate; ``deny_all`` refuses them.
+    The public SDK exposes no human-in-the-loop callback, so approvals are
+    not routed through ``ctx.on_interrupt``."""
+
+    effort: ReasoningEffort | None = None
+    """Per-turn reasoning effort override; ``None`` uses the model default."""
+
+    summary: ReasoningSummary | None = None
+    """Per-turn reasoning summary override; ``None`` uses the model default."""
+
+    output_schema: dict[str, object] | None = None
+    """JSON Schema constraining each turn's final assistant message."""
+
+    personality: Personality | None = None
+    """Assistant personality; ``None`` uses the Codex default."""
+
+    base_instructions: str | None = None
+    """Replacement base instructions for the thread."""
+
+    developer_instructions: str | None = None
+    """Additional developer instructions for the thread."""
+
+    cwd: str | None = None
+    """Working directory for the conversation thread; ``None`` uses the
+    app-server process's own working directory."""
+
+    resume_thread_id: str | None = None
+    """Resume this stored Codex thread instead of starting a fresh one.
+    ``fork()`` returns templates carrying this field."""
+
+    name: str = "codex"
+    """Name used for telemetry and when exposed as a Strands tool."""
+
+    description: str = ...
+    """Description used when exposed as a Strands tool."""
+
+    post_conditions: tuple[PostCondition, ...] = ()
+    """Validators run against each cycle's result. On failure the thread
+    feeds the failure messages back as the next user turn and re-runs, up to
+    ``max_attempts``. Empty (default) disables the retry loop — behaviour is
+    then a single query."""
+
+    max_attempts: int = 10
+    """Maximum number of cycles to satisfy ``post_conditions``. Ignored when
+    ``post_conditions`` is empty — the loop short-circuits after the first
+    query, so the default single-query behaviour is unchanged unless
+    ``post_conditions`` is set."""
+
+    @property
+    def input_shape(self) -> InputShape:
+        """Every CodexAgent thread accepts a single string prompt."""
+        ...
+
+    def to_thread(self) -> CodexAgentThread:
+        """Produce a fresh ``CodexAgentThread`` bound to this template.
+
+        The returned thread owns its own ``AsyncCodex`` client; the
+        ``codex app-server`` subprocess is not spawned until the first cycle
+        runs.
+
+        Ensures:
+            - Successive calls return independent instances with no shared state.
+            - No subprocess is started by this call.
+        """
+        ...
+
+    async def load_tools(self, **kwargs: object) -> Sequence[AgentTool]:
+        """Expose this template as a Strands tool.
+
+        The returned tool takes one ``prompt: str`` argument; each invocation
+        spawns a private ``CodexAgentThread``, runs a single cycle, and tears
+        it down.
+
+        Args:
+            kwargs: Ignored; present for protocol compatibility.
+
+        Returns:
+            A single-element list containing the ``AgentTool``.
+        """
+        ...
+
+    def add_consumer(self, consumer_id: Hashable, **kwargs: object) -> None:
+        """Register a tool-provider consumer.
+
+        Args:
+            consumer_id: Identifier of the agent consuming this tool.
+            kwargs: Ignored; present for protocol compatibility.
+        """
+        ...
+
+    def remove_consumer(self, consumer_id: Hashable, **kwargs: object) -> None:
+        """Deregister a tool-provider consumer.
+
+        Args:
+            consumer_id: Identifier of the agent releasing this tool.
+            kwargs: Ignored; present for protocol compatibility.
+        """
+        ...
+
+@final
+class CodexAgentThread(Thread[[str], str]):
+    """Live Codex-backed thread that owns one ``AsyncCodex`` client.
+
+    Connects lazily on the first cycle: launches ``codex app-server`` and
+    starts (or resumes) one conversation thread, both kept for the thread's
+    lifetime. The app-server owns conversation history; ai_functions observes
+    the notification stream and re-emits each element as a ai_functions
+    event — pure observability, not a source of truth.
+
+    Implements:
+        Thread[[str], str].
+
+    Lifecycle:
+        CREATED → CONNECTED → CLOSED.
+    """
+
+    def __init__(self, template: CodexAgent) -> None: ...
+    @property
+    def name(self) -> str:
+        """Thread name, taken from the owning ``CodexAgent`` template."""
+        ...
+
+    async def notify(self, text: str) -> None:
+        """Deliver ``text`` mid-turn via steering, or buffer it for the next turn.
+
+        With a turn in flight, the message is steered into it as additional
+        user input (scheduled as a background task so this call does not
+        block; a failed steer falls back to the buffer). Otherwise it sits in
+        the inject buffer and is prepended to the next ``execute`` prompt.
+
+        Args:
+            text: Message body delivered by the runtime or an external sender.
+
+        Ensures:
+            - The message reaches the session mid-turn or on the next turn.
+            - No new cycle is started by this call.
+        """
+        ...
+
+    async def execute(self, ctx: ThreadContext, prompt: str) -> str:
+        """Send ``prompt`` to the Codex thread and return its string result.
+
+        Runs the shared post-condition loop: the inject buffer is drained
+        into the outgoing turn, failures are fed back as the next user turn,
+        and the notification stream of each turn is re-emitted per the
+        mapping table in the implementation module's docstring.
+
+        Args:
+            ctx: Freshly built per-cycle context; never reused across cycles.
+            prompt: User prompt forwarded to the Codex thread.
+
+        Returns:
+            The turn's final assistant answer, or the empty string if the
+            turn produced no text.
+
+        Emits:
+            - MESSAGE_USER — per drained inject-buffer entry, per steered
+              message, plus one for ``prompt``.
+            - MESSAGE_ASSISTANT_START / _TOKEN / _COMPLETE — per agent message.
+            - MESSAGE_ASSISTANT_THINKING — per reasoning entry or delta.
+            - TOOL_CALL / TOOL_RESULT — per command, file-change, MCP,
+              dynamic-tool, or web-search item.
+            - TOKEN_USAGE — exactly one per turn.
+            - CustomEvent — codex_error / codex_plan / codex_* passthroughs.
+
+        Raises:
+            asyncio.CancelledError: ``ctx.cancel_signal`` was set — at the
+                cycle boundary, or mid-turn (the turn is interrupted first).
+            AIFunctionError: The turn failed, or post-conditions were not
+                satisfied within ``max_attempts`` attempts.
+        """
+        ...
+
+    async def fork(self) -> Spawnable[[str], str]:
+        """Fork the stored Codex conversation into a new template.
+
+        Codex forks the transcript server-side; the returned template resumes
+        the forked thread, so ``Coordinator.fork`` (which seeds the new
+        ai_functions event log from the source's) yields a divergent
+        continuation on both sides of the boundary.
+
+        Returns:
+            A ``CodexAgent`` carrying ``resume_thread_id`` of the fork — or
+            this thread's own template when no session exists yet, since a
+            never-connected thread's entire state is its template.
+        """
+        ...
+
+    async def teardown(self) -> None:
+        """Close the SDK client and release the ``codex app-server`` subprocess.
+
+        Ensures:
+            - Any running ``AsyncCodex`` client is closed.
+            - Pending inject-buffer entries are dropped.
+
+        Concurrency:
+            Idempotent; tearing down a never-connected thread is a no-op.
+        """
+        ...
+
+    def serialize_result(self, result: str) -> str:
+        """Return ``result`` unchanged; Codex results are already strings."""
+        ...
+
+    def deserialize_result(self, payload: str) -> str:
+        """Return ``payload`` unchanged; Codex results are already strings."""
+        ...
+
+    @property
+    def template(self) -> CodexAgent:
+        """The template this thread was created from."""
+        ...
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the app-server is running with a live conversation thread."""
+        ...
+
+    @property
+    def codex_thread_id(self) -> str | None:
+        """The Codex-side conversation thread id once connected, or ``None``."""
+        ...

--- a/spec/ai_functions/codex/codex.pyi
+++ b/spec/ai_functions/codex/codex.pyi
@@ -202,8 +202,9 @@ class CodexAgentThread(Thread[[str], str]):
             text: Message body delivered by the runtime or an external sender.
 
         Ensures:
-            - The message reaches the session mid-turn or on the next turn.
             - No new cycle is started by this call.
+            - A message that cannot be steered is buffered for the next turn,
+              unless :meth:`teardown` runs first.
         """
         ...
 
@@ -231,7 +232,8 @@ class CodexAgentThread(Thread[[str], str]):
             - TOOL_CALL / TOOL_RESULT — per command, file-change, MCP,
               dynamic-tool, or web-search item.
             - TOKEN_USAGE — exactly one per turn.
-            - CustomEvent — codex_error / codex_plan / codex_* passthroughs.
+            - CustomEvent — codex_error / codex_plan / codex_item_* /
+              codex_* passthroughs.
 
         Raises:
             asyncio.CancelledError: ``ctx.cancel_signal`` was set — at the
@@ -261,6 +263,7 @@ class CodexAgentThread(Thread[[str], str]):
 
         Ensures:
             - Any running ``AsyncCodex`` client is closed.
+            - In-flight steers are cancelled and awaited.
             - Pending inject-buffer entries are dropped.
 
         Concurrency:

--- a/spec/ai_functions/runtime/tool_server.pyi
+++ b/spec/ai_functions/runtime/tool_server.pyi
@@ -8,16 +8,16 @@ the process owning the coordinator.
 
 Clients must send the token in the ``Authorization: Bearer`` header.
 
-One server per worker; each thread registers to receive its own capability
-URL of the form ``http://127.0.0.1:<port>/mcp/<token>``.
+One server hosts any number of threads; each registration mints its own
+capability URL of the form ``http://127.0.0.1:<port>/mcp/<routing-id>``.
 
 The server binds 127.0.0.1 on a system-assigned port; pass the registration URL
 to the runtime as it starts. The port is reachable by any local process, so the
-*token* is the boundary: each registration mints a ``secrets``-grade token that
-must appear both in the URL path and in the ``Authorization: Bearer`` header
-(constant-time compared), the ``Host`` header must name the bound address
-(DNS-rebinding defense per the MCP spec's guidance for local HTTP servers), and
-deregistration revokes the token immediately.
+*token* is the boundary: each registration mints a ``secrets``-grade token
+required in the ``Authorization: Bearer`` header (constant-time compared), the
+``Host`` header must name the bound address (DNS-rebinding defense per the MCP
+spec's guidance for local HTTP servers), and deregistration revokes the token
+immediately.
 
 The MCP app runs stateless (``stateless_http=True``): tools and one-shot
 reads only — no server-initiated messages, no resource subscriptions.
@@ -36,23 +36,23 @@ class ToolServerRegistration:
     """One thread's capability to call the runtime tools."""
 
     url: str
-    """Full MCP endpoint for this thread, token embedded in the path."""
+    """Full MCP endpoint for this thread."""
 
     token: str
-    """The bare secret, for transports that pass it out of band (e.g. Codex's
-    ``bearer_token_env_var``). Required in the ``Authorization: Bearer`` header
-    on every request."""
+    """The bare secret, required in the ``Authorization: Bearer`` header on
+    every request. Codex takes it via ``bearer_token_env_var``."""
 
 @final
 class CoordinatorToolServer:
-    """One streamable-HTTP MCP server hosting the runtime tools for a worker.
+    """A streamable-HTTP MCP server hosting the runtime tools.
 
     Lifecycle:
         constructed → ``start()`` (binds and serves) → ``register`` /
         ``deregister`` per thread → ``stop()``.
 
     Concurrency:
-        ``start``/``stop`` are owned by the hosting worker's event loop.
+        ``start``/``stop`` must run on the same event loop — ``start`` spawns
+        the serving task there and ``stop`` awaits it.
         ``register``/``deregister`` are synchronous dict operations, safe to
         call between requests; per-request identity travels in a context
         variable, so concurrent requests for different threads never observe
@@ -92,7 +92,7 @@ class CoordinatorToolServer:
 
     @property
     def base_url(self) -> str:
-        """Root URL of the running server (no token).
+        """Root URL of the running server (no registration path).
 
         Raises:
             RuntimeError: The server is not started.
@@ -112,8 +112,8 @@ class CoordinatorToolServer:
                 ``continue_then_receive``.
 
         Returns:
-            The registration; hand ``url`` (and, for out-of-band transports,
-            ``token``) to the agent runtime's MCP config.
+            The registration; hand ``url`` and ``token`` to the agent runtime's
+            MCP config.
 
         Raises:
             RuntimeError: The server is not started.
@@ -121,7 +121,7 @@ class CoordinatorToolServer:
         ...
 
     def deregister(self, thread_id: ThreadId) -> None:
-        """Revoke ``thread_id``'s token; later requests with it 404.
+        """Revoke ``thread_id``'s registration; later requests to its URL 404.
 
         A request already dispatched keeps the registration it resolved for the
         rest of its lifetime; revocation is not a cancellation.

--- a/src/ai_functions/codex/__init__.py
+++ b/src/ai_functions/codex/__init__.py
@@ -1,0 +1,10 @@
+"""CodexAgentThread — a ``Spawnable``/``Thread`` pair backed by the OpenAI Codex SDK."""
+
+from __future__ import annotations
+
+from .codex import CodexAgent, CodexAgentThread
+
+__all__ = [
+    "CodexAgent",
+    "CodexAgentThread",
+]

--- a/src/ai_functions/codex/codex.py
+++ b/src/ai_functions/codex/codex.py
@@ -1,0 +1,820 @@
+"""``CodexAgent`` template and ``CodexAgentThread`` — OpenAI Codex-backed thread.
+
+A ``CodexAgentThread`` drives a ``codex app-server`` subprocess through the
+OpenAI Codex Python SDK (``openai_codex``). The app-server owns the
+conversation transcript; ai_functions observes its notification stream and
+re-emits each element through ``Coordinator.append_event`` as an observability
+shadow. I7/I9 do not apply (the app-server, not the runtime, owns history);
+the thread drains injected messages at work boundaries, supports pause, and
+delivers ``notify`` mid-turn by steering the in-flight turn.
+
+Codex-to-event mapping
+──────────────────────
+
+Every notification on ``AsyncTurnHandle.stream()`` maps to a fixed set of
+ai_functions events. No new built-in event kinds are introduced. Lifecycle
+events (``STARTED``, ``COMPLETED``, ``CANCELLED``, ``FAILED``, ``RESULT``) are
+emitted by the runtime dispatcher, never by the thread.
+
+- ``UserMessageThreadItem``: ignored (the thread already emitted
+  ``MESSAGE_USER`` when it sent the turn, and again when it steered).
+- ``AgentMessageThreadItem``: ``MESSAGE_ASSISTANT_START`` on ``item/started``
+  and ``MESSAGE_ASSISTANT_COMPLETE`` on ``item/completed``, both keyed by
+  ``MessageId(item.id)``; ``item/agentMessage/delta`` becomes
+  ``MESSAGE_ASSISTANT_TOKEN`` (``complete=False``).
+- ``ReasoningThreadItem`` on ``item/completed``: one
+  ``MESSAGE_ASSISTANT_THINKING`` (``complete=True``) per summary/content
+  entry; ``item/reasoning/textDelta`` and ``item/reasoning/summaryTextDelta``
+  become ``MESSAGE_ASSISTANT_THINKING`` (``complete=False``).
+- ``CommandExecutionThreadItem``, ``FileChangeThreadItem``,
+  ``McpToolCallThreadItem``, ``DynamicToolCallThreadItem``,
+  ``WebSearchThreadItem``: ``TOOL_CALL`` on ``item/started`` and
+  ``TOOL_RESULT`` on ``item/completed``, with ``tool_use_id=item.id``.
+  Command executions report ``status="error"`` for failed/declined runs or a
+  non-zero exit code; MCP and dynamic tool calls follow their own status
+  fields.
+- ``thread/tokenUsage/updated``: accumulated per turn from the ``last``
+  breakdown; exactly one ``TOKEN_USAGE`` is emitted per turn. Codex counts
+  cached tokens *inside* ``inputTokens``, so the event reports
+  ``input_tokens = inputTokens - cachedInputTokens`` and
+  ``cache_read_tokens = cachedInputTokens``, preserving the
+  ``input + cache_read + cache_write`` total identity.
+- ``error`` (``ErrorNotification``): ``CustomEvent(kind="codex_error")``.
+- ``turn/plan/updated`` / ``item/plan/delta`` / ``PlanThreadItem``:
+  ``CustomEvent(kind="codex_plan", payload=...)``.
+- ``turn/completed``: terminal. ``failed`` raises ``AIFunctionError`` with
+  the turn error's message; ``interrupted`` raises
+  ``asyncio.CancelledError``; ``completed`` yields the turn result.
+- Every other notification: ``CustomEvent(kind=f"codex_{method}")`` with
+  ``/`` replaced by ``_`` — the registry is large and versions with the CLI,
+  so unknown methods degrade to observability rather than errors.
+
+The turn's string result is the last ``final_answer``-phase agent message,
+falling back to the last message with no phase (mirrors the SDK's own
+``TurnResult`` collection). ``turn/completed`` carries ``items_view:
+not_loaded`` with an empty ``items`` list, so items are accumulated from the
+stream, never read from the completion payload.
+
+Invariants:
+    I2 — every emitted event goes through ``Coordinator.append_event``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from collections.abc import Hashable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast, final, override
+
+from strands.tools import ToolProvider
+from strands.tools.decorator import tool as _strands_tool  # pyright: ignore[reportUnknownVariableType]
+from strands.types.tools import AgentTool
+
+from ..ai_thread.errors import AIFunctionError
+from ..ai_thread.postcondition import PostCondition, run_post_condition_loop
+from ..protocols import Spawnable, Thread
+from ..types import (
+    CustomEvent,
+    InputShape,
+    MessageAssistantCompleteEvent,
+    MessageAssistantStartEvent,
+    MessageAssistantThinkingEvent,
+    MessageAssistantTokenEvent,
+    MessageId,
+    MessageUserEvent,
+    ThreadContext,
+    TokenUsage,
+    TokenUsageEvent,
+    ToolCallEvent,
+    ToolResultEvent,
+)
+
+try:
+    from openai_codex import ApprovalMode, AsyncCodex, Sandbox
+    from openai_codex.client import CodexConfig
+    from openai_codex.generated.v2_all import (
+        AgentMessageDeltaNotification,
+        AgentMessageThreadItem,
+        CommandExecutionThreadItem,
+        DynamicToolCallThreadItem,
+        ErrorNotification,
+        FileChangeThreadItem,
+        ItemCompletedNotification,
+        ItemStartedNotification,
+        McpToolCallThreadItem,
+        MessagePhase,
+        PlanThreadItem,
+        ReasoningSummaryTextDeltaNotification,
+        ReasoningTextDeltaNotification,
+        ReasoningThreadItem,
+        ThreadTokenUsageUpdatedNotification,
+        TurnCompletedNotification,
+        TurnStatus,
+        UserMessageThreadItem,
+        WebSearchThreadItem,
+    )
+    from openai_codex.models import Notification, UnknownNotification
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    raise ImportError(
+        "CodexAgent requires the optional 'codex' extra (the OpenAI Codex "
+        "SDK and its bundled runtime). Install it with:\n"
+        "    pip install 'strands-ai-functions[codex]'",
+    ) from exc
+
+if TYPE_CHECKING:
+    from openai_codex import AsyncThread, AsyncTurnHandle
+    from openai_codex.generated.v2_all import (
+        Personality,
+        ReasoningEffort,
+        ReasoningSummary,
+        ThreadTokenUsage,
+    )
+
+from pydantic import BaseModel
+
+
+def _item_root(item: object) -> object:
+    """Unwrap the generated ``ThreadItem`` RootModel to its concrete variant."""
+    return getattr(item, "root", item)
+
+
+def _status_value(status: object) -> str:
+    """Render a generated status enum (or anything else) as its wire string."""
+    value = getattr(status, "value", status)
+    return value if isinstance(value, str) else str(value)
+
+
+def _payload_dict(payload: object) -> dict[str, object]:
+    """Render a notification payload as a JSON-friendly dict for CustomEvent."""
+    if isinstance(payload, UnknownNotification):
+        return dict(payload.params)
+    if isinstance(payload, BaseModel):
+        dumped = payload.model_dump(mode="json", by_alias=True)
+        return dumped if isinstance(dumped, dict) else {"payload": dumped}
+    return {"payload": repr(payload)}
+
+
+def _tool_result_text(*parts: object) -> list[dict[str, str]]:
+    """Pack tool output fragments into Strands-shape text content blocks."""
+    texts = [str(p) for p in parts if p is not None and str(p) != ""]
+    return [{"text": t} for t in texts] if texts else []
+
+
+@dataclass
+class _TurnState:
+    """Mutable per-turn accumulator for stream consumption."""
+
+    turn_id: str
+    final_answer: str | None = None
+    last_unphased: str | None = None
+    usage: TokenUsage | None = None
+    completed: TurnCompletedNotification | None = None
+
+
+@final
+@dataclass(frozen=True)
+class CodexAgent(Spawnable[[str], str], ToolProvider):
+    """Immutable template for an OpenAI-Codex-backed thread.
+
+    Carries the configuration used to launch the ``codex app-server``
+    subprocess and start (or resume) its conversation thread, plus the
+    display metadata needed to expose the resulting thread as a Strands
+    tool. Picklable and safe to share across runtimes: session identity is
+    a string (``resume_thread_id``), so a template can travel to any host
+    that has Codex auth and an equivalent working directory.
+
+    Implements:
+        Spawnable, strands.tools.ToolProvider.
+
+    Immutable: Yes.
+    """
+
+    config: CodexConfig | None = None
+    """Launch configuration forwarded to the SDK client (binary path, cwd,
+    env, config overrides); ``None`` uses the bundled runtime's defaults."""
+
+    model: str | None = None
+    """Model id for the conversation thread; ``None`` uses the Codex default."""
+
+    sandbox: Sandbox | None = None
+    """Filesystem access preset (``read_only`` / ``workspace_write`` /
+    ``full_access``); ``None`` uses the Codex default."""
+
+    approval_mode: ApprovalMode = ApprovalMode.auto_review
+    """How escalated permission requests are resolved. ``auto_review`` (the
+    default) lets Codex's own reviewer arbitrate; ``deny_all`` refuses them.
+    The public SDK exposes no human-in-the-loop callback, so approvals are
+    not routed through ``ctx.on_interrupt``."""
+
+    effort: ReasoningEffort | None = None
+    """Per-turn reasoning effort override; ``None`` uses the model default."""
+
+    summary: ReasoningSummary | None = None
+    """Per-turn reasoning summary override; ``None`` uses the model default."""
+
+    output_schema: dict[str, object] | None = None
+    """JSON Schema constraining each turn's final assistant message."""
+
+    personality: Personality | None = None
+    """Assistant personality; ``None`` uses the Codex default."""
+
+    base_instructions: str | None = None
+    """Replacement base instructions for the thread."""
+
+    developer_instructions: str | None = None
+    """Additional developer instructions for the thread."""
+
+    cwd: str | None = None
+    """Working directory for the conversation thread; ``None`` uses the
+    app-server process's own working directory."""
+
+    resume_thread_id: str | None = None
+    """Resume this stored Codex thread instead of starting a fresh one.
+    ``fork()`` returns templates carrying this field."""
+
+    name: str = "codex"
+    """Name used for telemetry and when exposed as a Strands tool."""
+
+    description: str = "Send a prompt to a Codex agent and receive its final answer."
+    """Description used when exposed as a Strands tool."""
+
+    post_conditions: tuple[PostCondition, ...] = ()
+    """Validators run against each cycle's result. On failure the thread
+    feeds the failure messages back as the next user turn and re-runs, up to
+    ``max_attempts``. Empty (default) disables the retry loop — behaviour is
+    then a single query."""
+
+    max_attempts: int = 10
+    """Maximum number of cycles to satisfy ``post_conditions``. Ignored when
+    ``post_conditions`` is empty — the loop short-circuits after the first
+    query, so the default single-query behaviour is unchanged unless
+    ``post_conditions`` is set."""
+
+    @property
+    def input_shape(self) -> InputShape:
+        """Every CodexAgent thread accepts a single string prompt."""
+        return InputShape.STR_PROMPT
+
+    @override
+    def to_thread(self) -> CodexAgentThread:
+        """Produce a fresh ``CodexAgentThread`` bound to this template.
+
+        The returned thread owns its own ``AsyncCodex`` client; the
+        ``codex app-server`` subprocess is not spawned until the first cycle
+        runs.
+
+        Ensures:
+            - Successive calls return independent instances with no shared state.
+            - No subprocess is started by this call.
+        """
+        return CodexAgentThread(self)
+
+    @override
+    async def load_tools(self, **kwargs: object) -> Sequence[AgentTool]:
+        """Expose this template as a Strands tool.
+
+        The returned tool takes one ``prompt: str`` argument; each invocation
+        spawns a private ``CodexAgentThread``, runs a single cycle, and tears
+        it down.
+
+        Args:
+            kwargs: Ignored; present for protocol compatibility.
+
+        Returns:
+            A single-element list containing the ``AgentTool``.
+        """
+        from ..runtime.coordinator import InMemoryCoordinator
+        from ..runtime.worker import LocalWorker
+
+        template = self
+
+        @_strands_tool(name=self.name, description=self.description)
+        async def _invoke(prompt: str) -> str:
+            coord = InMemoryCoordinator()
+            worker = LocalWorker(coord)
+            handle = await worker.spawn_locally(template)
+            try:
+                return await handle.run(prompt)
+            finally:
+                await handle.terminate_now()
+
+        return [_invoke]
+
+    @override
+    def add_consumer(self, consumer_id: Hashable, **kwargs: object) -> None:
+        """Register a tool-provider consumer.
+
+        Args:
+            consumer_id: Identifier of the agent consuming this tool.
+            kwargs: Ignored; present for protocol compatibility.
+        """
+        return None
+
+    @override
+    def remove_consumer(self, consumer_id: Hashable, **kwargs: object) -> None:
+        """Deregister a tool-provider consumer.
+
+        Args:
+            consumer_id: Identifier of the agent releasing this tool.
+            kwargs: Ignored; present for protocol compatibility.
+        """
+        return None
+
+
+@final
+class CodexAgentThread(Thread[[str], str]):
+    """Live Codex-backed thread that owns one ``AsyncCodex`` client.
+
+    Connects lazily on the first cycle: launches ``codex app-server`` and
+    starts (or resumes) one conversation thread, both kept for the thread's
+    lifetime. The app-server owns conversation history; ai_functions observes
+    the notification stream and re-emits each element as a ai_functions
+    event — pure observability, not a source of truth. The module docstring
+    describes the full mapping.
+
+    Unlike the Claude and Kiro backends, this thread supports:
+
+    - real ``fork()`` — Codex forks the stored conversation server-side;
+    - mid-turn ``notify()`` — the message is steered into the in-flight turn;
+    - cooperative cancel that interrupts the in-flight turn rather than
+      waiting for the cycle boundary.
+
+    Implements:
+        Thread[[str], str].
+
+    Lifecycle:
+        CREATED → CONNECTED → CLOSED.
+    """
+
+    __slots__ = (
+        "_template",
+        "_codex",
+        "_thread",
+        "_connected",
+        "_connect_lock",
+        "_active_ctx",
+        "_active_turn",
+        "_inject_buffer",
+    )
+
+    def __init__(self, template: CodexAgent) -> None:
+        self._template: CodexAgent = template
+        self._codex: AsyncCodex | None = None
+        self._thread: AsyncThread | None = None
+        self._connected: bool = False
+        self._connect_lock: asyncio.Lock = asyncio.Lock()
+        # Populated for the duration of each cycle; the dispatcher serialises
+        # cycles, so reads from notify() during a cycle are safe.
+        self._active_ctx: ThreadContext | None = None
+        # The in-flight turn's handle, for steering and interruption.
+        self._active_turn: AsyncTurnHandle | None = None
+        # Pending side-channel messages delivered via ``notify`` while idle;
+        # prepended to the next outgoing user turn.
+        self._inject_buffer: list[str] = []
+
+    @property
+    def name(self) -> str:
+        """Thread name, taken from the owning ``CodexAgent`` template."""
+        return self._template.name
+
+    async def notify(self, text: str) -> None:
+        """Deliver ``text`` mid-turn via steering, or buffer it for the next turn.
+
+        With a turn in flight, the message is steered into it as additional
+        user input (scheduled as a background task so this call does not
+        block; a failed steer falls back to the buffer). Otherwise it sits in
+        the inject buffer and is prepended to the next ``execute`` prompt.
+
+        Args:
+            text: Message body delivered by the runtime or an external sender.
+
+        Ensures:
+            - The message reaches the session mid-turn or on the next turn.
+            - No new cycle is started by this call.
+        """
+        handle = self._active_turn
+        ctx = self._active_ctx
+        if handle is None or ctx is None:
+            self._inject_buffer.append(text)
+            return
+
+        async def _steer() -> None:
+            try:
+                _ = await handle.steer(text)
+                ctx.on_event(MessageUserEvent(text=text))
+            except Exception:  # noqa: BLE001 - the turn may have just completed
+                self._inject_buffer.append(text)
+
+        _ = asyncio.create_task(_steer())
+
+    async def execute(self, ctx: ThreadContext, prompt: str) -> str:
+        """Send ``prompt`` to the Codex thread and return its string result.
+
+        Runs the shared post-condition loop: the inject buffer is drained
+        into the outgoing turn, failures are fed back as the next user turn,
+        and the notification stream of each turn is re-emitted per the
+        mapping table in the module docstring.
+
+        Args:
+            ctx: Freshly built per-cycle context; never reused across cycles.
+            prompt: User prompt forwarded to the Codex thread.
+
+        Returns:
+            The turn's final assistant answer, or the empty string if the
+            turn produced no text.
+
+        Emits:
+            - MESSAGE_USER — per drained inject-buffer entry, per steered
+              message, plus one for ``prompt``.
+            - MESSAGE_ASSISTANT_START / _TOKEN / _COMPLETE — per agent message.
+            - MESSAGE_ASSISTANT_THINKING — per reasoning entry or delta.
+            - TOOL_CALL / TOOL_RESULT — per command, file-change, MCP,
+              dynamic-tool, or web-search item.
+            - TOKEN_USAGE — exactly one per turn.
+            - CustomEvent — codex_error / codex_plan / codex_* passthroughs.
+
+        Raises:
+            asyncio.CancelledError: ``ctx.cancel_signal`` was set — at the
+                cycle boundary, or mid-turn (the turn is interrupted first).
+            AIFunctionError: The turn failed, or post-conditions were not
+                satisfied within ``max_attempts`` attempts.
+        """
+        if ctx.cancel_signal.is_set():
+            raise asyncio.CancelledError
+        await ctx.coordinator.wait_until_unpaused(ctx.thread_id)
+        self._active_ctx = ctx
+        try:
+            await self._ensure_connected()
+
+            async def _send_turn(combined: str) -> str:
+                return await self._run_turn(ctx, combined)
+
+            return await run_post_condition_loop(
+                ctx,
+                prompt,
+                thread_name=self.name,
+                post_conditions=self._template.post_conditions,
+                max_attempts=self._template.max_attempts,
+                inject_buffer=self._inject_buffer,
+                send_turn=_send_turn,
+            )
+        finally:
+            self._active_ctx = None
+
+    async def fork(self) -> Spawnable[[str], str]:
+        """Fork the stored Codex conversation into a new template.
+
+        Codex forks the transcript server-side; the returned template resumes
+        the forked thread, so ``Coordinator.fork`` (which seeds the new
+        ai_functions event log from the source's) yields a divergent
+        continuation on both sides of the boundary.
+
+        Returns:
+            A ``CodexAgent`` carrying ``resume_thread_id`` of the fork — or
+            this thread's own template when no session exists yet, since a
+            never-connected thread's entire state is its template.
+        """
+        if self._codex is None or self._thread is None:
+            return self._template
+        forked = await self._codex.thread_fork(self._thread.id)
+        return dataclasses.replace(self._template, resume_thread_id=forked.id)
+
+    async def teardown(self) -> None:
+        """Close the SDK client and release the ``codex app-server`` subprocess.
+
+        Ensures:
+            - Any running ``AsyncCodex`` client is closed.
+            - Pending inject-buffer entries are dropped.
+
+        Concurrency:
+            Idempotent; tearing down a never-connected thread is a no-op.
+        """
+        self._inject_buffer.clear()
+        codex = self._codex
+        self._codex = None
+        self._thread = None
+        self._active_turn = None
+        self._connected = False
+        if codex is not None:
+            await codex.close()
+
+    def serialize_result(self, result: str) -> str:
+        """Return ``result`` unchanged; Codex results are already strings."""
+        return result
+
+    def deserialize_result(self, payload: str) -> str:
+        """Return ``payload`` unchanged; Codex results are already strings."""
+        return payload
+
+    @property
+    def template(self) -> CodexAgent:
+        """The template this thread was created from."""
+        return self._template
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the app-server is running with a live conversation thread."""
+        return self._connected
+
+    @property
+    def codex_thread_id(self) -> str | None:
+        """The Codex-side conversation thread id once connected, or ``None``."""
+        return None if self._thread is None else self._thread.id
+
+    # ── Internals ──
+
+    async def _ensure_connected(self) -> None:
+        """Lazily launch the app-server and start (or resume) the thread."""
+        if self._connected:
+            return
+        async with self._connect_lock:
+            if self._connected:
+                return
+            template = self._template
+            codex = AsyncCodex(config=template.config)
+            try:
+                if template.resume_thread_id is not None:
+                    thread = await codex.thread_resume(
+                        template.resume_thread_id,
+                        approval_mode=template.approval_mode,
+                        base_instructions=template.base_instructions,
+                        cwd=template.cwd,
+                        developer_instructions=template.developer_instructions,
+                        model=template.model,
+                        personality=template.personality,
+                        sandbox=template.sandbox,
+                    )
+                else:
+                    thread = await codex.thread_start(
+                        approval_mode=template.approval_mode,
+                        base_instructions=template.base_instructions,
+                        cwd=template.cwd,
+                        developer_instructions=template.developer_instructions,
+                        model=template.model,
+                        personality=template.personality,
+                        sandbox=template.sandbox,
+                    )
+            except BaseException:
+                await codex.close()
+                raise
+            self._codex = codex
+            self._thread = thread
+            self._connected = True
+
+    async def _run_turn(self, ctx: ThreadContext, combined: str) -> str:
+        """Start one turn, consume its stream, and return the final answer."""
+        assert self._thread is not None
+        template = self._template
+        handle = await self._thread.turn(
+            combined,
+            effort=template.effort,
+            output_schema=cast("Any", template.output_schema),  # pyright: ignore[reportExplicitAny]
+            summary=template.summary,
+        )
+        state = _TurnState(turn_id=handle.id)
+        self._active_turn = handle
+        watcher = asyncio.create_task(self._interrupt_on_cancel(ctx, handle))
+        try:
+            async for notification in handle.stream():
+                self._emit_notification(notification, ctx, state)
+        finally:
+            self._active_turn = None
+            _ = watcher.cancel()
+
+        if state.usage is not None:
+            ctx.on_event(TokenUsageEvent(token_usage=state.usage))
+
+        completed = state.completed
+        if completed is not None:
+            status = completed.turn.status
+            if status == TurnStatus.interrupted:
+                raise asyncio.CancelledError
+            if status == TurnStatus.failed:
+                error = completed.turn.error
+                message = error.message if error is not None and error.message else f"turn {status.value}"
+                raise AIFunctionError(message, function_name=self.name)
+
+        if state.final_answer is not None:
+            return state.final_answer
+        return state.last_unphased or ""
+
+    async def _interrupt_on_cancel(self, ctx: ThreadContext, handle: AsyncTurnHandle) -> None:
+        """Interrupt the in-flight turn when the cycle's cancel signal fires.
+
+        The interrupted turn completes with ``TurnStatus.interrupted``, which
+        ``_run_turn`` translates into ``asyncio.CancelledError`` — so cancel
+        takes effect mid-turn instead of waiting for the turn to finish.
+        """
+        await ctx.cancel_signal.wait()
+        try:
+            _ = await handle.interrupt()
+        except Exception:  # noqa: BLE001 - the turn may have just completed
+            pass
+
+    # ── Notification-to-event mapping ──
+
+    def _emit_notification(self, notification: Notification, ctx: ThreadContext, state: _TurnState) -> None:
+        """Translate one stream notification into ai_functions events."""
+        payload = notification.payload
+        if isinstance(payload, ItemStartedNotification):
+            self._emit_item_started(_item_root(payload.item), ctx)
+            return
+        if isinstance(payload, ItemCompletedNotification):
+            self._emit_item_completed(_item_root(payload.item), ctx, state)
+            return
+        if isinstance(payload, AgentMessageDeltaNotification):
+            ctx.on_event(
+                MessageAssistantTokenEvent(
+                    message_id=MessageId(payload.item_id),
+                    text=payload.delta,
+                    complete=False,
+                ),
+            )
+            return
+        if isinstance(payload, ReasoningTextDeltaNotification | ReasoningSummaryTextDeltaNotification):
+            ctx.on_event(
+                MessageAssistantThinkingEvent(
+                    message_id=MessageId(payload.item_id),
+                    text=payload.delta,
+                    complete=False,
+                ),
+            )
+            return
+        if isinstance(payload, ThreadTokenUsageUpdatedNotification):
+            if payload.turn_id == state.turn_id:
+                delta = _breakdown_to_token_usage(payload.token_usage)
+                state.usage = delta if state.usage is None else state.usage + delta
+            return
+        if isinstance(payload, TurnCompletedNotification):
+            if payload.turn.id == state.turn_id:
+                state.completed = payload
+            return
+        if isinstance(payload, ErrorNotification):
+            ctx.on_event(
+                CustomEvent(
+                    kind="codex_error",
+                    payload={"message": payload.error.message, "will_retry": payload.will_retry},
+                ),
+            )
+            return
+        if notification.method == "turn/started":
+            return  # the dispatcher owns lifecycle events
+        kind = "codex_plan" if "plan" in notification.method else f"codex_{notification.method.replace('/', '_')}"
+        ctx.on_event(CustomEvent(kind=kind, payload=_payload_dict(payload)))
+
+    def _emit_item_started(self, item: object, ctx: ThreadContext) -> None:
+        """Emit the opening event for one thread item."""
+        if isinstance(item, AgentMessageThreadItem):
+            ctx.on_event(MessageAssistantStartEvent(message_id=MessageId(item.id)))
+            return
+        call = _tool_call_for(item)
+        if call is not None:
+            ctx.on_event(call)
+
+    def _emit_item_completed(self, item: object, ctx: ThreadContext, state: _TurnState) -> None:
+        """Emit the closing event for one thread item and track the answer."""
+        if isinstance(item, UserMessageThreadItem):
+            return  # echo of our own input; MESSAGE_USER was emitted at send time
+        if isinstance(item, AgentMessageThreadItem):
+            ctx.on_event(
+                MessageAssistantCompleteEvent(
+                    message_id=MessageId(item.id),
+                    content=cast("Any", [{"text": item.text}]),  # pyright: ignore[reportExplicitAny]
+                ),
+            )
+            if item.phase == MessagePhase.final_answer:
+                state.final_answer = item.text
+            elif item.phase is None:
+                state.last_unphased = item.text
+            return
+        if isinstance(item, ReasoningThreadItem):
+            for entry in [*(item.summary or []), *(item.content or [])]:
+                if entry:
+                    ctx.on_event(
+                        MessageAssistantThinkingEvent(
+                            message_id=MessageId(item.id),
+                            text=entry,
+                            complete=True,
+                        ),
+                    )
+            return
+        if isinstance(item, PlanThreadItem):
+            ctx.on_event(CustomEvent(kind="codex_plan", payload={"id": item.id, "text": item.text}))
+            return
+        result = _tool_result_for(item)
+        if result is not None:
+            ctx.on_event(result)
+
+
+def _breakdown_to_token_usage(usage: ThreadTokenUsage) -> TokenUsage:
+    """Convert one ``last`` (per-model-call) breakdown to a ai_functions ``TokenUsage``.
+
+    Codex counts cached tokens inside ``inputTokens`` (verified live:
+    ``totalTokens == inputTokens + outputTokens`` with ``cachedInputTokens``
+    a subset of ``inputTokens``), while ``TokenUsage`` totals
+    ``input + cache_read + cache_write + output`` — so the cached share is
+    subtracted out of ``input_tokens``. Codex reports no cache-write figure.
+    """
+    last = usage.last
+    cached = last.cached_input_tokens
+    return TokenUsage(
+        input_tokens=max(0, last.input_tokens - cached),
+        output_tokens=last.output_tokens,
+        cache_read_tokens=cached,
+        cache_write_tokens=0,
+    )
+
+
+def _tool_call_for(item: object) -> ToolCallEvent | None:
+    """Build the ``TOOL_CALL`` event for a tool-shaped thread item, if any."""
+    if isinstance(item, CommandExecutionThreadItem):
+        return ToolCallEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            tool_name="command_execution",
+            arguments={"command": item.command, "cwd": str(item.cwd)},
+        )
+    if isinstance(item, FileChangeThreadItem):
+        changes = [change.model_dump(mode="json", by_alias=True) for change in item.changes]
+        return ToolCallEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            tool_name="file_change",
+            arguments={"changes": changes},
+        )
+    if isinstance(item, McpToolCallThreadItem):
+        raw = item.arguments
+        arguments = {str(k): v for k, v in raw.items()} if isinstance(raw, dict) else {"arguments": raw}
+        return ToolCallEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            tool_name=f"{item.server}.{item.tool}",
+            arguments=cast("dict[str, object]", arguments),
+        )
+    if isinstance(item, DynamicToolCallThreadItem):
+        raw = item.arguments
+        arguments = {str(k): v for k, v in raw.items()} if isinstance(raw, dict) else {"arguments": raw}
+        return ToolCallEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            tool_name=item.tool,
+            arguments=cast("dict[str, object]", arguments),
+        )
+    if isinstance(item, WebSearchThreadItem):
+        return ToolCallEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            tool_name="web_search",
+            arguments={"query": item.query},
+        )
+    return None
+
+
+def _tool_result_for(item: object) -> ToolResultEvent | None:
+    """Build the ``TOOL_RESULT`` event for a completed tool-shaped item, if any."""
+    if isinstance(item, CommandExecutionThreadItem):
+        failed = _status_value(item.status) in ("failed", "declined") or (
+            item.exit_code is not None and item.exit_code != 0
+        )
+        return ToolResultEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            status=cast("Any", "error" if failed else "success"),  # pyright: ignore[reportExplicitAny]
+            content=cast("Any", _tool_result_text(item.aggregated_output)),  # pyright: ignore[reportExplicitAny]
+        )
+    if isinstance(item, FileChangeThreadItem):
+        return ToolResultEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            status=cast("Any", "error" if _status_value(item.status) == "failed" else "success"),  # pyright: ignore[reportExplicitAny]
+            content=cast("Any", _tool_result_text(_status_value(item.status))),  # pyright: ignore[reportExplicitAny]
+        )
+    if isinstance(item, McpToolCallThreadItem):
+        failed = _status_value(item.status) == "failed" or item.error is not None
+        body = item.result.model_dump_json(by_alias=True) if item.result is not None else None
+        error_text = item.error.message if item.error is not None else None
+        return ToolResultEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            status=cast("Any", "error" if failed else "success"),  # pyright: ignore[reportExplicitAny]
+            content=cast("Any", _tool_result_text(error_text, body)),  # pyright: ignore[reportExplicitAny]
+        )
+    if isinstance(item, DynamicToolCallThreadItem):
+        failed = _status_value(item.status) == "failed" or item.success is False
+        parts = [c.model_dump_json(by_alias=True) for c in (item.content_items or [])]
+        return ToolResultEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            status=cast("Any", "error" if failed else "success"),  # pyright: ignore[reportExplicitAny]
+            content=cast("Any", _tool_result_text(*parts)),  # pyright: ignore[reportExplicitAny]
+        )
+    if isinstance(item, WebSearchThreadItem):
+        action = item.action.model_dump_json(by_alias=True) if item.action is not None else None
+        return ToolResultEvent(
+            message_id=None,
+            tool_use_id=item.id,
+            status=cast("Any", "success"),  # pyright: ignore[reportExplicitAny]
+            content=cast("Any", _tool_result_text(action or item.query)),  # pyright: ignore[reportExplicitAny]
+        )
+    return None

--- a/src/ai_functions/codex/codex.py
+++ b/src/ai_functions/codex/codex.py
@@ -59,6 +59,17 @@ falling back to the last message with no phase (mirrors the SDK's own
 not_loaded`` with an empty ``items`` list, so items are accumulated from the
 stream, never read from the completion payload.
 
+Runtime tools
+─────────────
+
+Codex reaches the runtime tools (``list_threads`` / ``send_message``) over
+HTTP MCP: each thread starts its own :class:`CoordinatorToolServer` when it
+connects, registers itself for a capability URL, and injects the endpoint
+into the app-server launch via ``--config`` overrides
+(``mcp_servers.ai_functions_runtime.url`` plus a ``bearer_token_env_var``
+naming an env var that carries the token). The server lives exactly as long
+as the connection: ``teardown`` stops it after closing the SDK client.
+
 Invariants:
     I2 — every emitted event goes through ``Coordinator.append_event``.
 """
@@ -79,6 +90,7 @@ from strands.types.tools import AgentTool
 from ..ai_thread.errors import AIFunctionError
 from ..ai_thread.postcondition import PostCondition, run_post_condition_loop
 from ..protocols import Spawnable, Thread
+from ..runtime.tool_server import CoordinatorToolServer, ToolServerRegistration
 from ..types import (
     CustomEvent,
     InputShape,
@@ -145,6 +157,42 @@ if TYPE_CHECKING:
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
+
+_RUNTIME_SERVER_KEY = "ai_functions_runtime"
+"""Key of the runtime-tools MCP server in the Codex config; tool calls surface
+as ``TOOL_CALL`` events named ``ai_functions_runtime.<tool>``."""
+
+_RUNTIME_TOKEN_ENV = "AI_FUNCTIONS_RUNTIME_TOKEN"
+"""Env var (in the app-server subprocess only) carrying the bearer token."""
+
+
+def _config_with_runtime_tools(config: CodexConfig | None, reg: ToolServerRegistration) -> CodexConfig:
+    """Return a copy of ``config`` pointing Codex at the runtime tool server.
+
+    Adds ``--config`` overrides registering ``reg.url`` as a streamable-HTTP
+    MCP server and routes its bearer token through the subprocess environment
+    (``bearer_token_env_var``), so the secret never appears on the command
+    line. The caller's own overrides and env are preserved.
+
+    Raises:
+        ValueError: ``config.config_overrides`` already configures the
+            reserved ``mcp_servers.ai_functions_runtime`` key.
+    """
+    base = config or CodexConfig()
+    reserved = f"mcp_servers.{_RUNTIME_SERVER_KEY}"
+    if any(override.lstrip().startswith(reserved) for override in base.config_overrides):
+        raise ValueError(
+            f"CodexConfig.config_overrides may not configure the reserved key "
+            f"{reserved!r}; ai_functions uses it for the runtime MCP server.",
+        )
+    overrides = (
+        f'{reserved}.url="{reg.url}"',
+        f'{reserved}.bearer_token_env_var="{_RUNTIME_TOKEN_ENV}"',
+    )
+    env = dict(base.env or {})
+    env[_RUNTIME_TOKEN_ENV] = reg.token
+    return dataclasses.replace(base, config_overrides=(*base.config_overrides, *overrides), env=env)
+
 
 _MAPPED_ITEM_TYPES = frozenset(
     {
@@ -386,6 +434,7 @@ class CodexAgentThread(Thread[[str], str]):
         "_template",
         "_codex",
         "_thread",
+        "_tool_server",
         "_connected",
         "_connect_lock",
         "_active_ctx",
@@ -398,6 +447,9 @@ class CodexAgentThread(Thread[[str], str]):
         self._template: CodexAgent = template
         self._codex: AsyncCodex | None = None
         self._thread: AsyncThread | None = None
+        # Started at connect time so Codex can call the runtime tools over
+        # HTTP MCP; lives exactly as long as the connection.
+        self._tool_server: CoordinatorToolServer | None = None
         self._connected: bool = False
         self._connect_lock: asyncio.Lock = asyncio.Lock()
         # Populated for the duration of each cycle; the dispatcher serialises
@@ -490,7 +542,7 @@ class CodexAgentThread(Thread[[str], str]):
         await ctx.coordinator.wait_until_unpaused(ctx.thread_id)
         self._active_ctx = ctx
         try:
-            await self._ensure_connected()
+            await self._ensure_connected(ctx)
 
             async def _send_turn(combined: str) -> str:
                 return await self._run_turn(ctx, combined)
@@ -530,6 +582,7 @@ class CodexAgentThread(Thread[[str], str]):
 
         Ensures:
             - Any running ``AsyncCodex`` client is closed.
+            - The runtime tool server is stopped and its token revoked.
             - In-flight steers are cancelled and awaited.
             - Pending inject-buffer entries are dropped.
 
@@ -546,12 +599,18 @@ class CodexAgentThread(Thread[[str], str]):
             _ = await asyncio.gather(*steers, return_exceptions=True)
         self._inject_buffer.clear()
         codex = self._codex
+        tool_server = self._tool_server
         self._codex = None
         self._thread = None
+        self._tool_server = None
         self._active_turn = None
         self._connected = False
+        # Close the client (killing the app-server) before stopping the tool
+        # server, so no live Codex process outlasts its tool endpoint.
         if codex is not None:
             await codex.close()
+        if tool_server is not None:
+            await tool_server.stop()
 
     def serialize_result(self, result: str) -> str:
         """Return ``result`` unchanged; Codex results are already strings."""
@@ -578,15 +637,27 @@ class CodexAgentThread(Thread[[str], str]):
 
     # ── Internals ──
 
-    async def _ensure_connected(self) -> None:
-        """Lazily launch the app-server and start (or resume) the thread."""
+    async def _ensure_connected(self, ctx: ThreadContext) -> None:
+        """Lazily launch the app-server and start (or resume) the thread.
+
+        Also starts this thread's :class:`CoordinatorToolServer` and injects
+        its capability URL into the app-server launch config, so the Codex
+        agent can call ``list_threads`` / ``send_message`` over HTTP MCP.
+        """
         if self._connected:
             return
         async with self._connect_lock:
             if self._connected:
                 return
             template = self._template
-            codex = AsyncCodex(config=template.config)
+            tool_server = CoordinatorToolServer()
+            await tool_server.start()
+            try:
+                reg = tool_server.register(ctx.coordinator, ctx.thread_id)
+                codex = AsyncCodex(config=_config_with_runtime_tools(template.config, reg))
+            except BaseException:
+                await tool_server.stop()
+                raise
             try:
                 if template.resume_thread_id is not None:
                     thread = await codex.thread_resume(
@@ -611,9 +682,11 @@ class CodexAgentThread(Thread[[str], str]):
                     )
             except BaseException:
                 await codex.close()
+                await tool_server.stop()
                 raise
             self._codex = codex
             self._thread = thread
+            self._tool_server = tool_server
             self._connected = True
 
     async def _run_turn(self, ctx: ThreadContext, combined: str) -> str:

--- a/src/ai_functions/codex/codex.py
+++ b/src/ai_functions/codex/codex.py
@@ -43,15 +43,12 @@ emitted by the runtime dispatcher, never by the thread.
 - ``turn/plan/updated`` / ``item/plan/delta`` / ``PlanThreadItem``:
   ``CustomEvent(kind="codex_plan", payload=...)``.
 - Every other thread item on ``item/completed``:
-  ``CustomEvent(kind=f"codex_item_{item.type}", payload=...)`` — the item union
-  grows with the CLI, so unmapped variants degrade to observability rather than
-  being dropped.
+  ``CustomEvent(kind=f"codex_item_{item.type}", payload=...)``.
 - ``turn/completed``: terminal. ``failed`` raises ``AIFunctionError`` with
   the turn error's message; ``interrupted`` raises
   ``asyncio.CancelledError``; ``completed`` yields the turn result.
 - Every other notification: ``CustomEvent(kind=f"codex_{method}")`` with
-  ``/`` replaced by ``_`` — the registry is large and versions with the CLI,
-  so unknown methods degrade to observability rather than errors.
+  ``/`` replaced by ``_``.
 
 The turn's string result is the last ``final_answer``-phase agent message,
 falling back to the last message with no phase (mirrors the SDK's own
@@ -123,9 +120,6 @@ try:
         UserMessageThreadItem,
         WebSearchThreadItem,
     )
-
-    # The notification types have a curated home in ``openai_codex.models``;
-    # only the thread-item classes and enums must come from the generated module.
     from openai_codex.models import (
         AgentMessageDeltaNotification,
         ErrorNotification,
@@ -170,9 +164,9 @@ def _config_with_runtime_tools(config: CodexConfig | None, reg: ToolServerRegist
     """Return a copy of ``config`` pointing Codex at the runtime tool server.
 
     Adds ``--config`` overrides registering ``reg.url`` as a streamable-HTTP
-    MCP server and routes its bearer token through the subprocess environment
-    (``bearer_token_env_var``), so the secret never appears on the command
-    line. The caller's own overrides and env are preserved.
+    MCP server, and puts its bearer token in the subprocess environment under
+    the name the ``bearer_token_env_var`` override points at. The caller's own
+    overrides and env are preserved.
 
     Raises:
         ValueError: ``config.config_overrides`` already configures the
@@ -589,8 +583,8 @@ class CodexAgentThread(Thread[[str], str]):
         Concurrency:
             Idempotent; tearing down a never-connected thread is a no-op.
         """
-        # Settle the steers before clearing the buffer: a steer failing after
-        # the clear would re-append to it on a torn-down thread.
+        # Settle the steers before clearing the buffer: a failing steer
+        # re-appends to it.
         steers = tuple(self._pending_steers)
         self._pending_steers.clear()
         for task in steers:

--- a/src/ai_functions/codex/codex.py
+++ b/src/ai_functions/codex/codex.py
@@ -42,6 +42,10 @@ emitted by the runtime dispatcher, never by the thread.
 - ``error`` (``ErrorNotification``): ``CustomEvent(kind="codex_error")``.
 - ``turn/plan/updated`` / ``item/plan/delta`` / ``PlanThreadItem``:
   ``CustomEvent(kind="codex_plan", payload=...)``.
+- Every other thread item on ``item/completed``:
+  ``CustomEvent(kind=f"codex_item_{item.type}", payload=...)`` — the item union
+  grows with the CLI, so unmapped variants degrade to observability rather than
+  being dropped.
 - ``turn/completed``: terminal. ``failed`` raises ``AIFunctionError`` with
   the turn error's message; ``interrupted`` raises
   ``asyncio.CancelledError``; ``completed`` yields the turn result.
@@ -63,6 +67,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 from collections.abc import Hashable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast, final, override
@@ -94,27 +99,33 @@ try:
     from openai_codex import ApprovalMode, AsyncCodex, Sandbox
     from openai_codex.client import CodexConfig
     from openai_codex.generated.v2_all import (
-        AgentMessageDeltaNotification,
         AgentMessageThreadItem,
         CommandExecutionThreadItem,
         DynamicToolCallThreadItem,
-        ErrorNotification,
         FileChangeThreadItem,
-        ItemCompletedNotification,
-        ItemStartedNotification,
         McpToolCallThreadItem,
         MessagePhase,
         PlanThreadItem,
-        ReasoningSummaryTextDeltaNotification,
-        ReasoningTextDeltaNotification,
         ReasoningThreadItem,
-        ThreadTokenUsageUpdatedNotification,
-        TurnCompletedNotification,
         TurnStatus,
         UserMessageThreadItem,
         WebSearchThreadItem,
     )
-    from openai_codex.models import Notification, UnknownNotification
+
+    # The notification types have a curated home in ``openai_codex.models``;
+    # only the thread-item classes and enums must come from the generated module.
+    from openai_codex.models import (
+        AgentMessageDeltaNotification,
+        ErrorNotification,
+        ItemCompletedNotification,
+        ItemStartedNotification,
+        Notification,
+        ReasoningSummaryTextDeltaNotification,
+        ReasoningTextDeltaNotification,
+        ThreadTokenUsageUpdatedNotification,
+        TurnCompletedNotification,
+        UnknownNotification,
+    )
 except ImportError as exc:  # pragma: no cover - exercised only without the extra
     raise ImportError(
         "CodexAgent requires the optional 'codex' extra (the OpenAI Codex "
@@ -133,10 +144,34 @@ if TYPE_CHECKING:
 
 from pydantic import BaseModel
 
+logger = logging.getLogger(__name__)
+
+_MAPPED_ITEM_TYPES = frozenset(
+    {
+        "userMessage",
+        "agentMessage",
+        "reasoning",
+        "plan",
+        "commandExecution",
+        "fileChange",
+        "mcpToolCall",
+        "dynamicToolCall",
+        "webSearch",
+    },
+)
+"""Wire discriminators of the thread items this adapter maps to typed events.
+Items outside this set are re-emitted as ``codex_item_*`` CustomEvents."""
+
 
 def _item_root(item: object) -> object:
     """Unwrap the generated ``ThreadItem`` RootModel to its concrete variant."""
     return getattr(item, "root", item)
+
+
+def _item_type(item: object) -> str:
+    """Wire discriminator of a thread item (``agentMessage``, ``webSearch``, …)."""
+    value = getattr(item, "type", None)
+    return value if isinstance(value, str) else "unknown"
 
 
 def _status_value(status: object) -> str:
@@ -356,6 +391,7 @@ class CodexAgentThread(Thread[[str], str]):
         "_active_ctx",
         "_active_turn",
         "_inject_buffer",
+        "_pending_steers",
     )
 
     def __init__(self, template: CodexAgent) -> None:
@@ -372,6 +408,9 @@ class CodexAgentThread(Thread[[str], str]):
         # Pending side-channel messages delivered via ``notify`` while idle;
         # prepended to the next outgoing user turn.
         self._inject_buffer: list[str] = []
+        # In-flight steer tasks, held so the loop keeps a strong reference and
+        # ``teardown`` can cancel them.
+        self._pending_steers: set[asyncio.Task[None]] = set()
 
     @property
     def name(self) -> str:
@@ -390,8 +429,9 @@ class CodexAgentThread(Thread[[str], str]):
             text: Message body delivered by the runtime or an external sender.
 
         Ensures:
-            - The message reaches the session mid-turn or on the next turn.
             - No new cycle is started by this call.
+            - A message that cannot be steered is buffered for the next turn,
+              unless :meth:`teardown` runs first.
         """
         handle = self._active_turn
         ctx = self._active_ctx
@@ -402,11 +442,15 @@ class CodexAgentThread(Thread[[str], str]):
         async def _steer() -> None:
             try:
                 _ = await handle.steer(text)
-                ctx.on_event(MessageUserEvent(text=text))
-            except Exception:  # noqa: BLE001 - the turn may have just completed
+            except Exception:
+                logger.exception("steering into turn %s failed; buffering for the next turn", handle.id)
                 self._inject_buffer.append(text)
+                return
+            ctx.on_event(MessageUserEvent(text=text))
 
-        _ = asyncio.create_task(_steer())
+        task = asyncio.create_task(_steer())
+        self._pending_steers.add(task)
+        task.add_done_callback(self._pending_steers.discard)
 
     async def execute(self, ctx: ThreadContext, prompt: str) -> str:
         """Send ``prompt`` to the Codex thread and return its string result.
@@ -432,7 +476,8 @@ class CodexAgentThread(Thread[[str], str]):
             - TOOL_CALL / TOOL_RESULT — per command, file-change, MCP,
               dynamic-tool, or web-search item.
             - TOKEN_USAGE — exactly one per turn.
-            - CustomEvent — codex_error / codex_plan / codex_* passthroughs.
+            - CustomEvent — codex_error / codex_plan / codex_item_* /
+              codex_* passthroughs.
 
         Raises:
             asyncio.CancelledError: ``ctx.cancel_signal`` was set — at the
@@ -485,11 +530,20 @@ class CodexAgentThread(Thread[[str], str]):
 
         Ensures:
             - Any running ``AsyncCodex`` client is closed.
+            - In-flight steers are cancelled and awaited.
             - Pending inject-buffer entries are dropped.
 
         Concurrency:
             Idempotent; tearing down a never-connected thread is a no-op.
         """
+        # Settle the steers before clearing the buffer: a steer failing after
+        # the clear would re-append to it on a torn-down thread.
+        steers = tuple(self._pending_steers)
+        self._pending_steers.clear()
+        for task in steers:
+            _ = task.cancel()
+        if steers:
+            _ = await asyncio.gather(*steers, return_exceptions=True)
         self._inject_buffer.clear()
         codex = self._codex
         self._codex = None
@@ -705,6 +759,10 @@ class CodexAgentThread(Thread[[str], str]):
         result = _tool_result_for(item)
         if result is not None:
             ctx.on_event(result)
+            return
+        item_type = _item_type(item)
+        if item_type not in _MAPPED_ITEM_TYPES:
+            ctx.on_event(CustomEvent(kind=f"codex_item_{item_type}", payload=_payload_dict(item)))
 
 
 def _breakdown_to_token_usage(usage: ThreadTokenUsage) -> TokenUsage:

--- a/src/ai_functions/runtime/tool_server.py
+++ b/src/ai_functions/runtime/tool_server.py
@@ -9,25 +9,25 @@ the process owning the coordinator.
 Clients must send the token in the ``Authorization: Bearer`` header (Codex:
 ``codex mcp add --url ... --bearer-token-env-var``).
 
-One server per worker. Each thread registers to receive its own capability
-URL::
+One server hosts any number of threads; each registration mints its own
+capability URL::
 
     server = CoordinatorToolServer()
     await server.start()
     reg = server.register(coordinator, thread_id)
-    # reg.url  -> http://127.0.0.1:<port>/mcp/<token>
-    # reg.token, for transports that pass the secret out of band
+    # reg.url   -> http://127.0.0.1:<port>/mcp/<routing-id>
+    # reg.token -> the secret for the Authorization header
     ...
     server.deregister(thread_id)
     await server.stop()
 
 The server binds 127.0.0.1 on a system-assigned port; pass ``reg.url`` to the
 runtime as it starts. The port is reachable by any local process, so the *token*
-is the boundary: each registration mints a ``secrets``-grade token that must
-appear both in the URL path and in the ``Authorization: Bearer`` header
-(constant-time compared), the ``Host`` header must name the bound address
-(DNS-rebinding defense per the MCP spec's guidance for local HTTP servers), and
-deregistration revokes the token immediately.
+is the boundary: each registration mints a ``secrets``-grade token required in
+the ``Authorization: Bearer`` header (constant-time compared), the ``Host``
+header must name the bound address (DNS-rebinding defense per the MCP spec's
+guidance for local HTTP servers), and deregistration revokes the token
+immediately.
 
 The MCP app runs stateless (``stateless_http=True``): tools and one-shot
 reads only — no server-initiated messages, no resource subscriptions.
@@ -85,17 +85,16 @@ class ToolServerRegistration:
     """One thread's capability to call the runtime tools."""
 
     url: str
-    """Full MCP endpoint for this thread, token embedded in the path."""
+    """Full MCP endpoint for this thread."""
 
     token: str
-    """The bare secret, for transports that pass it out of band (e.g. Codex's
-    ``bearer_token_env_var``). Required in the ``Authorization: Bearer`` header
-    on every request."""
+    """The bare secret, required in the ``Authorization: Bearer`` header on
+    every request. Codex takes it via ``bearer_token_env_var``."""
 
 
 @dataclass(frozen=True)
 class _Registration:
-    """Server-side binding of a token to the thread it acts as."""
+    """Server-side binding of a routing id to the thread it acts as."""
 
     coordinator: Coordinator
     thread_id: ThreadId
@@ -187,9 +186,9 @@ class _TokenRouter:
         if not path.startswith(prefix):
             await _plain_response(send, 404, "not found")
             return
-        token, _, rest = path[len(prefix) :].partition("/")
+        path_id, _, rest = path[len(prefix) :].partition("/")
 
-        registration = self._server._lookup(token)  # pyright: ignore[reportPrivateUsage]  # module-internal
+        registration = self._server._lookup(path_id)  # pyright: ignore[reportPrivateUsage]  # module-internal
         if registration is None:
             await _plain_response(send, 404, "not found")
             return
@@ -225,14 +224,15 @@ class _TokenRouter:
 
 @final
 class CoordinatorToolServer:
-    """One streamable-HTTP MCP server hosting the runtime tools for a worker.
+    """A streamable-HTTP MCP server hosting the runtime tools.
 
     Lifecycle:
         constructed → ``start()`` (binds and serves) → ``register`` /
         ``deregister`` per thread → ``stop()``.
 
     Concurrency:
-        ``start``/``stop`` are owned by the hosting worker's event loop.
+        ``start``/``stop`` must run on the same event loop — ``start`` spawns
+        the serving task there and ``stop`` awaits it.
         ``register``/``deregister`` are synchronous dict operations, safe to
         call between requests; per-request identity travels in a context
         variable, so concurrent requests for different threads never observe
@@ -315,7 +315,7 @@ class CoordinatorToolServer:
 
     @property
     def base_url(self) -> str:
-        """Root URL of the running server (no token).
+        """Root URL of the running server (no registration path).
 
         Raises:
             RuntimeError: The server is not started.
@@ -339,8 +339,8 @@ class CoordinatorToolServer:
                 ``continue_then_receive``.
 
         Returns:
-            The registration; hand ``url`` (and, for out-of-band transports,
-            ``token``) to the agent runtime's MCP config.
+            The registration; hand ``url`` and ``token`` to the agent runtime's
+            MCP config.
 
         Raises:
             RuntimeError: The server is not started.
@@ -348,17 +348,18 @@ class CoordinatorToolServer:
         if self._bound_port is None:
             raise RuntimeError("CoordinatorToolServer is not started; call start() first")
         self.deregister(thread_id)
+        path_id = secrets.token_urlsafe(8)
         token = secrets.token_urlsafe(32)
-        self._registrations[token] = _Registration(
+        self._registrations[path_id] = _Registration(
             coordinator=coordinator,
             thread_id=thread_id,
             token=token,
         )
-        self._by_thread[thread_id] = token
-        return ToolServerRegistration(url=f"{self.base_url}/mcp/{token}", token=token)
+        self._by_thread[thread_id] = path_id
+        return ToolServerRegistration(url=f"{self.base_url}/mcp/{path_id}", token=token)
 
     def deregister(self, thread_id: ThreadId) -> None:
-        """Revoke ``thread_id``'s token; later requests with it 404.
+        """Revoke ``thread_id``'s registration; later requests to its URL 404.
 
         A request already dispatched keeps the registration it resolved for the
         rest of its lifetime; revocation is not a cancellation.
@@ -372,9 +373,9 @@ class CoordinatorToolServer:
 
     # ── Internals ──
 
-    def _lookup(self, token: str) -> _Registration | None:
-        """Resolve a path token to its registration; ``None`` when revoked/unknown."""
-        return self._registrations.get(token)
+    def _lookup(self, path_id: str) -> _Registration | None:
+        """Resolve a URL routing id to its registration; ``None`` when revoked/unknown."""
+        return self._registrations.get(path_id)
 
     @staticmethod
     def _bind_socket() -> socket.socket:

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -78,6 +78,9 @@ ai_functions.optimizer.textgrad.logger
 ai_functions.memory.agentcore_backend.logger
 ai_functions.memory.base.logger
 
+# Codex adapter module logger is internal implementation detail.
+ai_functions.codex.codex.logger
+
 # economics: module-level loggers are private implementation detail
 ai_functions.experimental.economics.beliefs.logger
 ai_functions.experimental.economics.function.logger

--- a/tests/codex_mock_model.py
+++ b/tests/codex_mock_model.py
@@ -1,0 +1,190 @@
+"""Hermetic model backend for Codex integration tests.
+
+The ``codex app-server`` binary is real (it ships with the ``openai-codex``
+SDK); only the *model* is mocked: a local HTTP server impersonates the OpenAI
+Responses API, and an isolated ``CODEX_HOME`` config routes the app-server's
+model provider at it. Tests script the model's SSE outputs and read back the
+exact requests the app-server sent, so turn structure, notifications, and
+token accounting are all produced by the real protocol implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+from openai_codex.client import CodexConfig
+
+Json = dict[str, Any]
+
+
+def sse_body(events: list[Json]) -> str:
+    """Frame Responses-API event objects as one SSE body."""
+    chunks = [f"event: {event['type']}\ndata: {json.dumps(event)}\n" for event in events]
+    return "\n".join(chunks) + "\n"
+
+
+def assistant_turn(
+    text: str,
+    *,
+    response_id: str = "resp-1",
+    input_tokens: int = 100,
+    cached_input_tokens: int = 40,
+    output_tokens: int = 7,
+) -> list[Json]:
+    """One complete assistant-message model response with explicit usage."""
+    return [
+        {"type": "response.created", "response": {"id": response_id}},
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "message",
+                "role": "assistant",
+                "id": f"msg-{response_id}",
+                "content": [{"type": "output_text", "text": text}],
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": response_id,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "input_tokens_details": {"cached_tokens": cached_input_tokens},
+                    "output_tokens": output_tokens,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": input_tokens + output_tokens,
+                },
+            },
+        },
+    ]
+
+
+class MockModelServer:
+    """Threaded HTTP server standing in for the Responses API."""
+
+    def __init__(self) -> None:
+        self._queue: queue.Queue[str] = queue.Queue()
+        self.requests: list[Json] = []
+        self._lock = threading.Lock()
+        self._httpd = _Server(("127.0.0.1", 0), _Handler, self)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+
+    def __enter__(self) -> MockModelServer:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+
+    @property
+    def url(self) -> str:
+        host, port = self._httpd.server_address[:2]
+        return f"http://{host}:{port}"
+
+    def enqueue(self, events: list[Json]) -> None:
+        """Queue the SSE response for the next model call."""
+        self._queue.put(sse_body(events))
+
+    def user_texts(self, request_index: int) -> list[str]:
+        """All user-role input_text strings in the recorded request."""
+        texts: list[str] = []
+        for item in self.requests[request_index].get("input", []):
+            if item.get("type") != "message" or item.get("role") != "user":
+                continue
+            content = item.get("content")
+            if isinstance(content, str):
+                texts.append(content)
+                continue
+            for span in content or []:
+                if isinstance(span, dict) and span.get("type") == "input_text":
+                    texts.append(str(span.get("text", "")))
+        return texts
+
+    def _record(self, body: bytes) -> None:
+        with self._lock:
+            self.requests.append(json.loads(body.decode("utf-8")))
+
+    def _next(self) -> str:
+        return self._queue.get_nowait()
+
+
+class _Server(ThreadingHTTPServer):
+    def __init__(self, addr: tuple[str, int], handler: type[BaseHTTPRequestHandler], mock: MockModelServer) -> None:
+        super().__init__(addr, handler)
+        self.mock = mock
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: _Server
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return None
+
+    def do_GET(self) -> None:
+        if self.path.endswith("/models"):
+            body = json.dumps(
+                {"object": "list", "data": [{"id": "mock-model", "object": "model", "created": 0, "owned_by": "t"}]},
+            ).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        self.server.mock._record(self.rfile.read(length))  # pyright: ignore[reportPrivateUsage]
+        if not self.path.endswith("/responses"):
+            self.send_error(404)
+            return
+        try:
+            body = self.server.mock._next()  # pyright: ignore[reportPrivateUsage]
+        except queue.Empty:
+            self.send_error(500, "no queued model response")
+            return
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.end_headers()
+        self.wfile.write(body.encode())
+        self.wfile.flush()
+
+
+def codex_test_config(tmp_path: Path, model_url: str) -> CodexConfig:
+    """An isolated CodexConfig whose model provider is the mock server."""
+    home = tmp_path / "codex-home"
+    workspace = tmp_path / "workspace"
+    home.mkdir(exist_ok=True)
+    workspace.mkdir(exist_ok=True)
+    (home / "config.toml").write_text(
+        f"""
+model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "read-only"
+
+model_provider = "mock_provider"
+
+[model_providers.mock_provider]
+name = "Mock provider for ai_functions tests"
+base_url = "{model_url}/v1"
+wire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
+""".lstrip(),
+    )
+    return CodexConfig(
+        cwd=str(workspace),
+        env={
+            "CODEX_HOME": str(home),
+            "CODEX_APP_SERVER_DISABLE_MANAGED_CONFIG": "1",
+            "RUST_LOG": "warn",
+        },
+    )

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -18,6 +18,7 @@ import pytest
 pytest.importorskip("openai_codex")
 
 from codex_mock_model import MockModelServer, assistant_turn, codex_test_config  # noqa: E402
+from openai_codex.client import CodexConfig  # noqa: E402
 from openai_codex.generated.v2_all import (  # noqa: E402
     AgentMessageDeltaNotification,
     AgentMessageThreadItem,
@@ -32,8 +33,15 @@ from openai_codex.generated.v2_all import (  # noqa: E402
 )
 from openai_codex.models import Notification, UnknownNotification  # noqa: E402
 
-from ai_functions.codex.codex import CodexAgent, CodexAgentThread, _TurnState  # noqa: E402
+from ai_functions.codex.codex import (  # noqa: E402
+    _RUNTIME_TOKEN_ENV,
+    CodexAgent,
+    CodexAgentThread,
+    _config_with_runtime_tools,
+    _TurnState,
+)
 from ai_functions.runtime import InMemoryCoordinator, LocalWorker  # noqa: E402
+from ai_functions.runtime.tool_server import ToolServerRegistration  # noqa: E402
 from ai_functions.types import Event, ThreadContext, ThreadId  # noqa: E402
 from ai_functions.types.events import EventKind  # noqa: E402
 
@@ -237,6 +245,39 @@ async def test_unknown_notification_becomes_custom_event() -> None:
     assert event.payload == {"x": 1}
 
 
+def test_runtime_tools_config_injects_url_and_token() -> None:
+    """The launch config gains the MCP server overrides; the token rides the env."""
+    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/tok", token="tok")
+    base = CodexConfig(config_overrides=('model="o3"',), env={"KEEP": "1"})
+    merged = _config_with_runtime_tools(base, reg)
+
+    assert merged.config_overrides == (
+        'model="o3"',
+        'mcp_servers.ai_functions_runtime.url="http://127.0.0.1:1234/mcp/tok"',
+        f'mcp_servers.ai_functions_runtime.bearer_token_env_var="{_RUNTIME_TOKEN_ENV}"',
+    )
+    assert merged.env == {"KEEP": "1", _RUNTIME_TOKEN_ENV: "tok"}
+    # The original config is untouched (dataclasses.replace semantics).
+    assert base.config_overrides == ('model="o3"',)
+    assert base.env == {"KEEP": "1"}
+
+
+def test_runtime_tools_config_accepts_none() -> None:
+    """A template with no config still gets a wired launch config."""
+    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/tok", token="tok")
+    merged = _config_with_runtime_tools(None, reg)
+    assert any(o.startswith("mcp_servers.ai_functions_runtime.url=") for o in merged.config_overrides)
+    assert merged.env == {_RUNTIME_TOKEN_ENV: "tok"}
+
+
+def test_runtime_tools_config_rejects_reserved_key() -> None:
+    """User overrides may not squat on the reserved MCP server key."""
+    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/tok", token="tok")
+    base = CodexConfig(config_overrides=('mcp_servers.ai_functions_runtime.url="http://evil"',))
+    with pytest.raises(ValueError, match="reserved"):
+        _ = _config_with_runtime_tools(base, reg)
+
+
 async def test_notify_while_idle_buffers() -> None:
     """With no turn in flight, notify() parks the message for the next turn."""
     thread = _thread()
@@ -370,3 +411,24 @@ async def test_fork_resumes_a_distinct_codex_thread(tmp_path: Path) -> None:
             assert forked.resume_thread_id != source_id
         finally:
             await thread.teardown()
+
+
+@pytest.mark.integration
+async def test_runtime_tools_reach_the_model(tmp_path: Path) -> None:
+    """The app-server connects to this thread's tool server and offers the
+    runtime tools to the model; teardown stops the server."""
+    with MockModelServer() as model:
+        model.enqueue(assistant_turn("ok", response_id="r1"))
+        template = CodexAgent(config=codex_test_config(tmp_path, model.url))
+        thread = template.to_thread()
+        rec = _Recorder()
+        try:
+            _ = await asyncio.wait_for(thread.execute(rec.ctx(), "hello"), timeout=120)
+            # The recorded model request proves the whole chain: the app-server
+            # resolved our config overrides, fetched the tool list over HTTP
+            # MCP (bearer token and all), and exposed it to the model.
+            tool_names = [t.get("name") for t in model.requests[0].get("tools", [])]
+            assert "mcp__ai_functions_runtime" in tool_names
+        finally:
+            await thread.teardown()
+        assert thread._tool_server is None  # pyright: ignore[reportPrivateUsage]

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -246,17 +246,18 @@ async def test_unknown_notification_becomes_custom_event() -> None:
 
 
 def test_runtime_tools_config_injects_url_and_token() -> None:
-    """The launch config gains the MCP server overrides; the token rides the env."""
-    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/tok", token="tok")
+    """The launch config gains the MCP server overrides; the token rides the env, not them."""
+    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/not-a-real-id", token="not-a-real-token")
     base = CodexConfig(config_overrides=('model="o3"',), env={"KEEP": "1"})
     merged = _config_with_runtime_tools(base, reg)
 
     assert merged.config_overrides == (
         'model="o3"',
-        'mcp_servers.ai_functions_runtime.url="http://127.0.0.1:1234/mcp/tok"',
+        'mcp_servers.ai_functions_runtime.url="http://127.0.0.1:1234/mcp/not-a-real-id"',
         f'mcp_servers.ai_functions_runtime.bearer_token_env_var="{_RUNTIME_TOKEN_ENV}"',
     )
-    assert merged.env == {"KEEP": "1", _RUNTIME_TOKEN_ENV: "tok"}
+    assert merged.env == {"KEEP": "1", _RUNTIME_TOKEN_ENV: "not-a-real-token"}
+    assert not any(reg.token in override for override in merged.config_overrides)
     # The original config is untouched (dataclasses.replace semantics).
     assert base.config_overrides == ('model="o3"',)
     assert base.env == {"KEEP": "1"}
@@ -264,15 +265,15 @@ def test_runtime_tools_config_injects_url_and_token() -> None:
 
 def test_runtime_tools_config_accepts_none() -> None:
     """A template with no config still gets a wired launch config."""
-    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/tok", token="tok")
+    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/not-a-real-id", token="not-a-real-token")
     merged = _config_with_runtime_tools(None, reg)
     assert any(o.startswith("mcp_servers.ai_functions_runtime.url=") for o in merged.config_overrides)
-    assert merged.env == {_RUNTIME_TOKEN_ENV: "tok"}
+    assert merged.env == {_RUNTIME_TOKEN_ENV: "not-a-real-token"}
 
 
 def test_runtime_tools_config_rejects_reserved_key() -> None:
     """User overrides may not squat on the reserved MCP server key."""
-    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/tok", token="tok")
+    reg = ToolServerRegistration(url="http://127.0.0.1:1234/mcp/not-a-real-id", token="not-a-real-token")
     base = CodexConfig(config_overrides=('mcp_servers.ai_functions_runtime.url="http://evil"',))
     with pytest.raises(ValueError, match="reserved"):
         _ = _config_with_runtime_tools(base, reg)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1,0 +1,372 @@
+"""``CodexAgent`` / ``CodexAgentThread`` — the OpenAI Codex backend.
+
+Two tiers. Unit tests feed synthetic SDK notification models straight into
+the mapping and pin the Codex-to-event table without any subprocess.
+Integration tests run the real ``codex app-server`` binary (bundled with the
+``openai-codex`` dependency) against a mocked model backend
+(``codex_mock_model``), so turn structure, notification framing, and token
+accounting come from the real protocol implementation while staying hermetic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("openai_codex")
+
+from codex_mock_model import MockModelServer, assistant_turn, codex_test_config  # noqa: E402
+from openai_codex.generated.v2_all import (  # noqa: E402
+    AgentMessageDeltaNotification,
+    AgentMessageThreadItem,
+    CommandExecutionStatus,
+    CommandExecutionThreadItem,
+    McpToolCallStatus,
+    McpToolCallThreadItem,
+    MessagePhase,
+    ThreadTokenUsage,
+    ThreadTokenUsageUpdatedNotification,
+    TokenUsageBreakdown,
+)
+from openai_codex.models import Notification, UnknownNotification  # noqa: E402
+
+from ai_functions.codex.codex import CodexAgent, CodexAgentThread, _TurnState  # noqa: E402
+from ai_functions.runtime import InMemoryCoordinator, LocalWorker  # noqa: E402
+from ai_functions.types import Event, ThreadContext, ThreadId  # noqa: E402
+from ai_functions.types.events import EventKind  # noqa: E402
+
+
+class _NeverPausedCoordinator:
+    """Just enough Coordinator for execute()'s cycle-boundary pause check."""
+
+    async def wait_until_unpaused(self, thread_id: ThreadId) -> None:
+        return None
+
+
+class _Recorder:
+    """A ThreadContext whose event sink records everything."""
+
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+
+    def ctx(self) -> ThreadContext:
+        return ThreadContext(
+            thread_id=ThreadId("t-codex"),
+            coordinator=_NeverPausedCoordinator(),  # type: ignore[arg-type]  # structural stub
+            on_event=self.events.append,
+            on_interrupt=None,  # type: ignore[arg-type]  # mapping never touches it
+            pause_signal=asyncio.Event(),
+            cancel_signal=asyncio.Event(),
+        )
+
+    def kinds(self) -> list[object]:
+        return [e.kind for e in self.events]
+
+
+def _thread() -> CodexAgentThread:
+    return CodexAgentThread(CodexAgent())
+
+
+def _breakdown(input_tokens: int, cached: int, output: int) -> TokenUsageBreakdown:
+    return TokenUsageBreakdown(
+        input_tokens=input_tokens,
+        cached_input_tokens=cached,
+        output_tokens=output,
+        reasoning_output_tokens=0,
+        total_tokens=input_tokens + output,
+    )
+
+
+def _usage_notification(turn_id: str, input_tokens: int, cached: int, output: int) -> Notification:
+    payload = ThreadTokenUsageUpdatedNotification(
+        thread_id="th-1",
+        turn_id=turn_id,
+        token_usage=ThreadTokenUsage(
+            last=_breakdown(input_tokens, cached, output),
+            total=_breakdown(input_tokens, cached, output),
+        ),
+    )
+    return Notification(method="thread/tokenUsage/updated", payload=payload)
+
+
+# ── Unit tier: the mapping table ─────────────────────────────────────────────
+
+
+async def test_agent_message_spans_start_token_complete() -> None:
+    """An agent message maps to START on started, TOKEN per delta, COMPLETE on completed."""
+    rec = _Recorder()
+    ctx = rec.ctx()
+    thread = _thread()
+    state = _TurnState(turn_id="turn-1")
+
+    item = AgentMessageThreadItem(id="msg-1", text="", type="agentMessage", phase=MessagePhase.final_answer)
+    thread._emit_item_started(item, ctx)  # pyright: ignore[reportPrivateUsage]
+    thread._emit_notification(  # pyright: ignore[reportPrivateUsage]
+        Notification(
+            method="item/agentMessage/delta",
+            payload=AgentMessageDeltaNotification(item_id="msg-1", thread_id="th-1", turn_id="turn-1", delta="hel"),
+        ),
+        ctx,
+        state,
+    )
+    done = AgentMessageThreadItem(id="msg-1", text="hello", type="agentMessage", phase=MessagePhase.final_answer)
+    thread._emit_item_completed(done, ctx, state)  # pyright: ignore[reportPrivateUsage]
+
+    assert rec.kinds() == [
+        EventKind.MESSAGE_ASSISTANT_START,
+        EventKind.MESSAGE_ASSISTANT_TOKEN,
+        EventKind.MESSAGE_ASSISTANT_COMPLETE,
+    ]
+    assert state.final_answer == "hello"
+    # All three events share the item's id as the message id.
+    ids = {getattr(e, "message_id", None) for e in rec.events}
+    assert ids == {"msg-1"}
+
+
+async def test_command_execution_maps_to_tool_call_and_result() -> None:
+    """A command item is a TOOL_CALL on start and a TOOL_RESULT on completion."""
+    rec = _Recorder()
+    ctx = rec.ctx()
+    thread = _thread()
+    state = _TurnState(turn_id="turn-1")
+
+    running = CommandExecutionThreadItem(
+        id="call-1",
+        type="commandExecution",
+        command="echo hi",
+        cwd="/tmp",
+        command_actions=[],
+        status=CommandExecutionStatus.in_progress,
+    )
+    thread._emit_item_started(running, ctx)  # pyright: ignore[reportPrivateUsage]
+    done = CommandExecutionThreadItem(
+        id="call-1",
+        type="commandExecution",
+        command="echo hi",
+        cwd="/tmp",
+        command_actions=[],
+        status=CommandExecutionStatus.completed,
+        exit_code=0,
+        aggregated_output="hi\n",
+    )
+    thread._emit_item_completed(done, ctx, state)  # pyright: ignore[reportPrivateUsage]
+
+    call, result = rec.events
+    assert call.kind == EventKind.TOOL_CALL
+    assert call.tool_name == "command_execution"
+    assert call.arguments["command"] == "echo hi"
+    assert result.kind == EventKind.TOOL_RESULT
+    assert result.status == "success"
+    assert result.content == [{"text": "hi\n"}]
+    assert call.tool_use_id == result.tool_use_id == "call-1"
+
+
+async def test_failed_command_reports_error_status() -> None:
+    """Non-zero exit code or failed/declined status becomes status='error'."""
+    rec = _Recorder()
+    thread = _thread()
+    state = _TurnState(turn_id="turn-1")
+    failed = CommandExecutionThreadItem(
+        id="call-2",
+        type="commandExecution",
+        command="false",
+        cwd="/tmp",
+        command_actions=[],
+        status=CommandExecutionStatus.completed,
+        exit_code=1,
+        aggregated_output="",
+    )
+    thread._emit_item_completed(failed, rec.ctx(), state)  # pyright: ignore[reportPrivateUsage]
+    assert rec.events[0].status == "error"
+
+
+async def test_mcp_tool_call_uses_server_dot_tool_name() -> None:
+    """MCP tool items surface as '<server>.<tool>' with their arguments."""
+    rec = _Recorder()
+    thread = _thread()
+    item = McpToolCallThreadItem(
+        id="mcp-1",
+        type="mcpToolCall",
+        server="aif_runtime",
+        tool="send_message",
+        arguments={"thread_id": "t-2", "message": "hi"},
+        status=McpToolCallStatus.in_progress,
+    )
+    thread._emit_item_started(item, rec.ctx())  # pyright: ignore[reportPrivateUsage]
+    call = rec.events[0]
+    assert call.tool_name == "aif_runtime.send_message"
+    assert call.arguments == {"thread_id": "t-2", "message": "hi"}
+
+
+async def test_token_usage_accumulates_and_subtracts_cached() -> None:
+    """Per-call `last` breakdowns sum; cached tokens move out of input_tokens."""
+    rec = _Recorder()
+    ctx = rec.ctx()
+    thread = _thread()
+    state = _TurnState(turn_id="turn-1")
+
+    thread._emit_notification(_usage_notification("turn-1", 100, 40, 10), ctx, state)  # pyright: ignore[reportPrivateUsage]
+    thread._emit_notification(_usage_notification("turn-1", 200, 150, 5), ctx, state)  # pyright: ignore[reportPrivateUsage]
+    # A different turn's usage must not leak in.
+    thread._emit_notification(_usage_notification("turn-OTHER", 999, 0, 999), ctx, state)  # pyright: ignore[reportPrivateUsage]
+
+    usage = state.usage
+    assert usage is not None
+    assert usage.input_tokens == (100 - 40) + (200 - 150)
+    assert usage.cache_read_tokens == 40 + 150
+    assert usage.output_tokens == 15
+    assert usage.cache_write_tokens == 0
+    # Usage is not emitted per notification; the turn emits exactly one at the end.
+    assert EventKind.TOKEN_USAGE not in rec.kinds()
+
+
+async def test_unknown_notification_becomes_custom_event() -> None:
+    """Unknown methods degrade to CustomEvent('codex_<method>'), never raise."""
+    rec = _Recorder()
+    thread = _thread()
+    state = _TurnState(turn_id="turn-1")
+    thread._emit_notification(  # pyright: ignore[reportPrivateUsage]
+        Notification(method="thread/somethingNew", payload=UnknownNotification(params={"x": 1})),
+        rec.ctx(),
+        state,
+    )
+    event = rec.events[0]
+    assert event.kind == "codex_thread_somethingNew"
+    assert event.payload == {"x": 1}
+
+
+async def test_notify_while_idle_buffers() -> None:
+    """With no turn in flight, notify() parks the message for the next turn."""
+    thread = _thread()
+    await thread.notify("a note")
+    assert thread._inject_buffer == ["a note"]  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_fork_of_unconnected_thread_returns_template() -> None:
+    """A never-connected thread's entire state is its template."""
+    template = CodexAgent(name="forky")
+    thread = CodexAgentThread(template)
+    assert await thread.fork() is template
+
+
+async def test_serialize_round_trip_is_identity() -> None:
+    thread = _thread()
+    assert thread.serialize_result("x") == "x"
+    assert thread.deserialize_result("x") == "x"
+
+
+async def test_teardown_never_connected_is_noop() -> None:
+    thread = _thread()
+    await thread.teardown()
+    assert not thread.is_connected
+
+
+async def test_interrupt_watcher_fires_on_cancel_signal() -> None:
+    """The watcher calls handle.interrupt() when the cycle's cancel signal sets."""
+
+    class _Handle:
+        def __init__(self) -> None:
+            self.interrupted = asyncio.Event()
+
+        async def interrupt(self) -> None:
+            self.interrupted.set()
+
+    rec = _Recorder()
+    ctx = rec.ctx()
+    thread = _thread()
+    handle = _Handle()
+    watcher = asyncio.create_task(thread._interrupt_on_cancel(ctx, handle))  # pyright: ignore[reportPrivateUsage, reportArgumentType]
+    ctx.cancel_signal.set()
+    await asyncio.wait_for(handle.interrupted.wait(), timeout=2)
+    await watcher
+
+
+# ── Integration tier: real app-server, mocked model ──────────────────────────
+
+
+@pytest.mark.integration
+async def test_execute_returns_answer_and_shadows_events(tmp_path: Path) -> None:
+    """One cycle end-to-end: result text, message events, one TOKEN_USAGE."""
+    with MockModelServer() as model:
+        model.enqueue(assistant_turn("the answer is 4", input_tokens=100, cached_input_tokens=40, output_tokens=7))
+        template = CodexAgent(config=codex_test_config(tmp_path, model.url))
+        coord = InMemoryCoordinator()
+        worker = await LocalWorker(coord).register()
+        handle = await worker.spawn_locally(template, thread_name="codex")
+        try:
+            result = await asyncio.wait_for(handle.run("what is 2+2?"), timeout=120)
+            assert result == "the answer is 4"
+
+            events = await coord.get_events(handle.id)
+            kinds = [e.kind for e in events]
+            assert EventKind.MESSAGE_USER in kinds
+            assert EventKind.MESSAGE_ASSISTANT_COMPLETE in kinds
+            usage_events = [e for e in events if e.kind == EventKind.TOKEN_USAGE]
+            assert len(usage_events) == 1
+            usage = usage_events[0].token_usage
+            assert usage.input_tokens == 60  # 100 raw minus 40 cached
+            assert usage.cache_read_tokens == 40
+            assert usage.output_tokens == 7
+        finally:
+            await handle.terminate_now()
+            await worker.close()
+
+
+@pytest.mark.integration
+async def test_post_condition_failure_rides_next_turn(tmp_path: Path) -> None:
+    """A failing post-condition feeds back as the next user turn, prompt sent once."""
+
+    def must_mention_four(result: str):  # noqa: ANN202
+        from ai_functions.ai_thread.postcondition import PostConditionResult
+
+        if "4" in result:
+            return PostConditionResult(passed=True)
+        return PostConditionResult(passed=False, message="the answer must contain the digit 4")
+
+    with MockModelServer() as model:
+        model.enqueue(assistant_turn("I refuse to answer", response_id="r1"))
+        model.enqueue(assistant_turn("fine, it is 4", response_id="r2"))
+        template = CodexAgent(
+            config=codex_test_config(tmp_path, model.url),
+            post_conditions=(must_mention_four,),
+            max_attempts=3,
+        )
+        coord = InMemoryCoordinator()
+        worker = await LocalWorker(coord).register()
+        handle = await worker.spawn_locally(template, thread_name="codex")
+        try:
+            result = await asyncio.wait_for(handle.run("what is 2+2?"), timeout=120)
+            assert result == "fine, it is 4"
+
+            assert len(model.requests) == 2
+            first_turn_texts = " ".join(model.user_texts(0))
+            retry_texts = " ".join(model.user_texts(1))
+            assert "what is 2+2?" in first_turn_texts
+            assert "Post-condition failures" in retry_texts
+            assert "must contain the digit 4" in retry_texts
+        finally:
+            await handle.terminate_now()
+            await worker.close()
+
+
+@pytest.mark.integration
+async def test_fork_resumes_a_distinct_codex_thread(tmp_path: Path) -> None:
+    """fork() returns a template resuming a server-side fork of the transcript."""
+    with MockModelServer() as model:
+        model.enqueue(assistant_turn("first reply", response_id="r1"))
+        template = CodexAgent(config=codex_test_config(tmp_path, model.url))
+        thread = template.to_thread()
+        rec = _Recorder()
+        try:
+            _ = await asyncio.wait_for(thread.execute(rec.ctx(), "hello"), timeout=120)
+            source_id = thread.codex_thread_id
+            assert source_id is not None
+
+            forked = await thread.fork()
+            assert isinstance(forked, CodexAgent)
+            assert forked.resume_thread_id is not None
+            assert forked.resume_thread_id != source_id
+        finally:
+            await thread.teardown()

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -140,8 +140,14 @@ async def test_tools_work_with_no_cycle_in_flight(server: CoordinatorToolServer)
     assert '"is_self":true' in text.replace(" ", "")
 
 
+async def test_url_path_is_a_routing_id(server: CoordinatorToolServer) -> None:
+    """The URL path routes to the registration; the token is not part of it."""
+    reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    assert reg.token not in reg.url
+
+
 async def test_header_token_is_required(server: CoordinatorToolServer) -> None:
-    """The path token alone is not enough; the bearer header must match it."""
+    """Every request must carry its own registration's token in the header."""
     coord = _StubCoordinator()
     alice = server.register(coord, ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
     bob = server.register(coord, ThreadId("t-bob"))  # pyright: ignore[reportArgumentType]
@@ -155,11 +161,11 @@ async def test_header_token_is_required(server: CoordinatorToolServer) -> None:
         assert r.status_code == 401
 
 
-async def test_unknown_token_is_not_found(server: CoordinatorToolServer) -> None:
-    """A fabricated path token is rejected before any tool logic runs."""
+async def test_unknown_routing_id_is_not_found(server: CoordinatorToolServer) -> None:
+    """A fabricated path is rejected before any tool logic runs."""
     async with httpx.AsyncClient() as client:
         r = await client.post(
-            f"{server.base_url}/mcp/not-a-real-token",
+            f"{server.base_url}/mcp/not-a-real-id",
             json={},
             headers={"Authorization": "Bearer not-a-real-token"},
         )


### PR DESCRIPTION
**Stack position: 4 of 4**, on top of #37 (CoordinatorToolServer) ← #36 (shared post-condition loop) ← #35 (ACP 0.12). Shows predecessors' commits until they merge; diffs collapse on rebase after each squash. Uses `run_post_condition_loop` from #36; does not yet consume #37 (see Scope).

## What this is

A third foreign-runtime backend beside `claude_code` and `kiro`: `CodexAgent` / `CodexAgentThread` drive a `codex app-server` subprocess through the OpenAI Codex Python SDK (`openai-codex`, new `codex` extra — the SDK bundles its own runtime binary, so no separate install). The app-server owns the transcript; ai_functions shadows its notification stream as events, per the mapping table in the module docstring.

## Capabilities the other two backends don't have

- **`fork()` is real.** Codex forks the stored conversation server-side; the returned template resumes the fork, so `Coordinator.fork` yields a divergent continuation on both sides of the boundary. Claude and Kiro raise `NotImplementedError` here — this is the first foreign runtime where the whole fork path works.
- **`notify()` reaches a running turn** by steering it as additional user input (verified against a live Codex session during planning: steer keeps the same turn id and the text lands in the in-flight stream). Idle threads buffer for the next turn, as the other backends do.
- **Cancel interrupts mid-turn.** A watcher maps `ctx.cancel_signal` → `turn/interrupt`; the interrupted turn raises `CancelledError` rather than running to completion. (The Claude backend honours cancel only at cycle boundaries.)
- **Meaningfully picklable template** — session identity is a string (`resume_thread_id`).

## Token accounting

Codex counts cached tokens *inside* `inputTokens` (verified live: `totalTokens == inputTokens + outputTokens`, cached a subset of input), while `TokenUsage` totals `input + cache_read + cache_write + output`. The per-turn `TOKEN_USAGE` therefore reports `input_tokens = inputTokens − cachedInputTokens` and `cache_read_tokens = cachedInputTokens`. Exactly one usage event per turn, summed from the per-model-call `last` breakdowns; a test pins the arithmetic and that another turn's usage can't leak in.

One protocol landmine encoded in the implementation: `turn/completed` arrives with `items: []` and `items_view: not_loaded`, so items are accumulated from the stream and never read from the completion payload.

## Approvals

The public SDK exposes only `ApprovalMode.auto_review` / `deny_all` — there is no human-in-the-loop callback — so approvals are **not** routed through `ctx.on_interrupt`, and the docstring says so. (Probed during planning: with `auto_review` + workspace sandbox, in-sandbox commands fired zero approval requests; Codex's own reviewer arbitrates.)

## Testing strategy

Two tiers, mirroring how the SDK tests itself:

- **Unit (11 tests, no subprocess):** synthetic SDK notification models fed straight into the mapping — message spans share the item id, command/MCP/dynamic tool call+result pairs, error statuses (non-zero exit, failed/declined), usage arithmetic and per-turn isolation, unknown methods degrading to `CustomEvent` instead of raising, idle-notify buffering, unconnected-fork identity, interrupt watcher.
- **Integration (3 tests, hermetic):** the **real** `codex app-server` binary (bundled with the dependency) against a mocked Responses API (`tests/codex_mock_model.py`) with an isolated `CODEX_HOME` — so turn structure, notification framing, and token accounting come from the real protocol implementation, no network, no auth, ~4s total. Covers end-to-end `execute` through `LocalWorker` (result + event shadow + usage arithmetic), the post-condition feedback turn (asserted in the *captured model requests*: prompt sent once, retry carries the failure text), and server-side fork producing a distinct thread id. Marked `@pytest.mark.integration` (marker registered in pyproject).

## Scope

Runtime tools are not wired: a Codex session does not yet get `list_threads`/`send_message`. The wiring (via #37's `CoordinatorToolServer`, whose Codex config path — `mcp_servers.<name>.url` + `bearer_token_env_var` — was probed working end-to-end during planning) is a deliberate follow-up so this PR stays reviewable. Docs (README/tutorial) also follow with the wiring, to avoid documenting the backend twice.

Note on the dependency: the env resolves `openai-codex` 0.147.0 (floor pin `>=0.144.4`); SDK releases track CLI releases. The integration tier runs against whatever version resolves, which is exactly the drift these tests exist to catch — unknown notification methods degrade to `CustomEvent` by design.

## Verification

445 passed / 2 skipped (14 new), ruff clean, stubtest clean (79 modules, including the new spec stubs), pyright 0 errors on the new module.
