### PR TITLE
fix(codex): runtime tools survive more than one thread; forks are runnable

### DIFF
--- a/spec/ai_functions/codex/codex.pyi
+++ b/spec/ai_functions/codex/codex.pyi
@@ -8,13 +8,16 @@ implementation module's docstring carries the full Codex-to-event mapping.
 
 Distinguishing capabilities relative to the Claude and Kiro backends:
 
-- ``fork()`` is real — Codex forks the stored conversation server-side and
-  the returned template resumes the fork.
+- ``fork()`` is real — Codex branches the stored conversation server-side.
+  The returned template names its branch point and the forked thread's own
+  app-server creates the fork when it connects, because Codex allows one
+  writer per stored thread: a fork created by the source's app-server could
+  not be resumed by anyone else while the source lives.
 - ``notify()`` reaches a *running* turn by steering it, not only the next one.
 - Cooperative cancel interrupts the in-flight turn rather than waiting for
   the cycle boundary.
 - The template is meaningfully picklable: session identity is a string
-  (``resume_thread_id``).
+  (``resume_thread_id`` / ``fork_of_thread_id``).
 
 Approvals: the public SDK exposes only ``ApprovalMode.auto_review`` /
 ``deny_all`` — there is no human-in-the-loop callback, so approvals are not
@@ -50,11 +53,12 @@ class CodexAgent(Spawnable[[str], str], ToolProvider):
     """Immutable template for an OpenAI-Codex-backed thread.
 
     Carries the configuration used to launch the ``codex app-server``
-    subprocess and start (or resume) its conversation thread, plus the
-    display metadata needed to expose the resulting thread as a Strands
-    tool. Picklable and safe to share across runtimes: session identity is
-    a string (``resume_thread_id``), so a template can travel to any host
-    that has Codex auth and an equivalent working directory.
+    subprocess and start (or resume, or branch from) its conversation thread,
+    plus the display metadata needed to expose the resulting thread as a
+    Strands tool. Picklable and safe to share across runtimes: session identity
+    is a string (``resume_thread_id`` / ``fork_of_thread_id``), so a template
+    can travel to any host that has Codex auth and an equivalent working
+    directory.
 
     Implements:
         Spawnable, strands.tools.ToolProvider.
@@ -102,8 +106,14 @@ class CodexAgent(Spawnable[[str], str], ToolProvider):
     app-server process's own working directory."""
 
     resume_thread_id: str | None = None
-    """Resume this stored Codex thread instead of starting a fresh one.
-    ``fork()`` returns templates carrying this field."""
+    """Resume this stored Codex thread instead of starting a fresh one. Only one
+    app-server may write to a thread at a time, so resuming a thread another
+    live thread already holds is refused by Codex."""
+
+    fork_of_thread_id: str | None = None
+    """Branch from this stored Codex thread instead of resuming it: the thread
+    forks it on connect and owns the fork. ``fork()`` returns templates
+    carrying this field. Takes precedence over ``resume_thread_id``."""
 
     name: str = "codex"
     """Name used for telemetry and when exposed as a Strands tool."""
@@ -251,17 +261,27 @@ class CodexAgentThread(Thread[[str], str]):
         ...
 
     async def fork(self) -> Spawnable[[str], str]:
-        """Fork the stored Codex conversation into a new template.
+        """Return a template that branches from this thread's conversation.
 
-        Codex forks the transcript server-side; the returned template resumes
-        the forked thread, so ``Coordinator.fork`` (which seeds the new
-        ai_functions event log from the source's) yields a divergent
-        continuation on both sides of the boundary.
+        The returned template names this conversation as its branch point; the
+        fork itself is created by that template's own app-server on connect, so
+        that the writer of the fork is its creator. Codex permits one writer per
+        stored thread, so a fork created here could not be resumed elsewhere
+        while this thread lives. ``Coordinator.fork`` seeds the new ai_functions
+        event log from this thread's, so the result is a divergent continuation
+        on both sides of the boundary.
+
+        The branch point is the source transcript as it stands when the fork
+        first connects. The fork inherits the source thread's personality;
+        ``CodexAgent.personality`` is not re-applied.
 
         Returns:
-            A ``CodexAgent`` carrying ``resume_thread_id`` of the fork — or
-            this thread's own template when no session exists yet, since a
-            never-connected thread's entire state is its template.
+            A ``CodexAgent`` carrying ``fork_of_thread_id`` — or this thread's
+            own template when no session exists yet, since a never-connected
+            thread's entire state is its template.
+
+        Ensures:
+            - No Codex RPC is issued; this thread remains connected and usable.
         """
         ...
 

--- a/spec/ai_functions/runtime/tool_server.pyi
+++ b/spec/ai_functions/runtime/tool_server.pyi
@@ -19,8 +19,9 @@ required in the ``Authorization: Bearer`` header (constant-time compared), the
 spec's guidance for local HTTP servers), and deregistration revokes the token
 immediately.
 
-The MCP app runs stateless (``stateless_http=True``): tools and one-shot
-reads only — no server-initiated messages, no resource subscriptions.
+The MCP app runs stateless (``stateless_http=True``) and answers in JSON
+(``json_response=True``): tools and one-shot reads only — no server-initiated
+messages, no resource subscriptions, so nothing needs an SSE stream.
 
 Requires the ``runtime-tools`` extra (``mcp``, ``uvicorn``).
 """
@@ -84,6 +85,11 @@ class CoordinatorToolServer:
         In-flight tool calls are dropped rather than drained: a client waiting
         on one (``send_message(mode="wait")``, say) sees the connection close
         mid-response.
+
+        Ensures:
+            - The listening socket is closed, so the port is free once this
+              returns.
+            - No later server in this process is affected by this one stopping.
 
         Concurrency:
             Idempotent; stopping a never-started server is a no-op.

--- a/src/ai_functions/codex/codex.py
+++ b/src/ai_functions/codex/codex.py
@@ -56,6 +56,22 @@ falling back to the last message with no phase (mirrors the SDK's own
 not_loaded`` with an empty ``items`` list, so items are accumulated from the
 stream, never read from the completion payload.
 
+Forking
+───────
+
+Codex allows exactly one writer per stored thread: the app-server that has a
+thread loaded holds its writer lock, and any other app-server asking to resume
+it is refused ("thread ... already has an active writer"). Forking, by
+contrast, only reads the source, so any app-server may fork a thread another
+one is writing to — or one nobody has loaded.
+
+``fork()`` therefore records the branch point (``fork_of_thread_id``) rather
+than creating the fork, and the forked thread's own app-server calls
+``thread/fork`` when it connects — the writer of a fork is always its creator,
+and the source keeps running untouched. Consequences: the branch point is the
+source transcript as it stands when the fork first connects, and spawning one
+forked template twice yields two independent forks.
+
 Runtime tools
 ─────────────
 
@@ -255,11 +271,12 @@ class CodexAgent(Spawnable[[str], str], ToolProvider):
     """Immutable template for an OpenAI-Codex-backed thread.
 
     Carries the configuration used to launch the ``codex app-server``
-    subprocess and start (or resume) its conversation thread, plus the
-    display metadata needed to expose the resulting thread as a Strands
-    tool. Picklable and safe to share across runtimes: session identity is
-    a string (``resume_thread_id``), so a template can travel to any host
-    that has Codex auth and an equivalent working directory.
+    subprocess and start (or resume, or branch from) its conversation thread,
+    plus the display metadata needed to expose the resulting thread as a
+    Strands tool. Picklable and safe to share across runtimes: session identity
+    is a string (``resume_thread_id`` / ``fork_of_thread_id``), so a template
+    can travel to any host that has Codex auth and an equivalent working
+    directory.
 
     Implements:
         Spawnable, strands.tools.ToolProvider.
@@ -307,8 +324,14 @@ class CodexAgent(Spawnable[[str], str], ToolProvider):
     app-server process's own working directory."""
 
     resume_thread_id: str | None = None
-    """Resume this stored Codex thread instead of starting a fresh one.
-    ``fork()`` returns templates carrying this field."""
+    """Resume this stored Codex thread instead of starting a fresh one. Only one
+    app-server may write to a thread at a time, so resuming a thread another
+    live thread already holds is refused by Codex."""
+
+    fork_of_thread_id: str | None = None
+    """Branch from this stored Codex thread instead of resuming it: the thread
+    forks it on connect and owns the fork. ``fork()`` returns templates
+    carrying this field. Takes precedence over ``resume_thread_id``."""
 
     name: str = "codex"
     """Name used for telemetry and when exposed as a Strands tool."""
@@ -412,7 +435,8 @@ class CodexAgentThread(Thread[[str], str]):
 
     Unlike the Claude and Kiro backends, this thread supports:
 
-    - real ``fork()`` — Codex forks the stored conversation server-side;
+    - real ``fork()`` — Codex branches the stored conversation server-side,
+      with the fork created by the app-server that will write to it;
     - mid-turn ``notify()`` — the message is steered into the in-flight turn;
     - cooperative cancel that interrupts the in-flight turn rather than
       waiting for the cycle boundary.
@@ -554,22 +578,34 @@ class CodexAgentThread(Thread[[str], str]):
             self._active_ctx = None
 
     async def fork(self) -> Spawnable[[str], str]:
-        """Fork the stored Codex conversation into a new template.
+        """Return a template that branches from this thread's conversation.
 
-        Codex forks the transcript server-side; the returned template resumes
-        the forked thread, so ``Coordinator.fork`` (which seeds the new
-        ai_functions event log from the source's) yields a divergent
-        continuation on both sides of the boundary.
+        The returned template names this conversation as its branch point; the
+        fork itself is created by that template's own app-server on connect, so
+        that the writer of the fork is its creator (see the module docstring's
+        "Forking" section). ``Coordinator.fork`` seeds the new ai_functions
+        event log from this thread's, so the result is a divergent continuation
+        on both sides of the boundary.
+
+        The branch point is the source transcript as it stands when the fork
+        first connects. The fork inherits the source thread's personality;
+        ``CodexAgent.personality`` is not re-applied.
 
         Returns:
-            A ``CodexAgent`` carrying ``resume_thread_id`` of the fork — or
-            this thread's own template when no session exists yet, since a
-            never-connected thread's entire state is its template.
+            A ``CodexAgent`` carrying ``fork_of_thread_id`` — or this thread's
+            own template when no session exists yet, since a never-connected
+            thread's entire state is its template.
+
+        Ensures:
+            - No Codex RPC is issued; this thread remains connected and usable.
         """
-        if self._codex is None or self._thread is None:
+        if self._thread is None:
             return self._template
-        forked = await self._codex.thread_fork(self._thread.id)
-        return dataclasses.replace(self._template, resume_thread_id=forked.id)
+        return dataclasses.replace(
+            self._template,
+            fork_of_thread_id=self._thread.id,
+            resume_thread_id=None,
+        )
 
     async def teardown(self) -> None:
         """Close the SDK client and release the ``codex app-server`` subprocess.
@@ -653,7 +689,21 @@ class CodexAgentThread(Thread[[str], str]):
                 await tool_server.stop()
                 raise
             try:
-                if template.resume_thread_id is not None:
+                if template.fork_of_thread_id is not None:
+                    # Forking only reads the source, so this succeeds whether or
+                    # not another app-server holds the source's writer lock.
+                    # ``personality`` has no fork parameter; the fork inherits
+                    # the source's.
+                    thread = await codex.thread_fork(
+                        template.fork_of_thread_id,
+                        approval_mode=template.approval_mode,
+                        base_instructions=template.base_instructions,
+                        cwd=template.cwd,
+                        developer_instructions=template.developer_instructions,
+                        model=template.model,
+                        sandbox=template.sandbox,
+                    )
+                elif template.resume_thread_id is not None:
                     thread = await codex.thread_resume(
                         template.resume_thread_id,
                         approval_mode=template.approval_mode,

--- a/src/ai_functions/runtime/tool_server.py
+++ b/src/ai_functions/runtime/tool_server.py
@@ -29,9 +29,10 @@ header must name the bound address (DNS-rebinding defense per the MCP spec's
 guidance for local HTTP servers), and deregistration revokes the token
 immediately.
 
-The MCP app runs stateless (``stateless_http=True``): tools and one-shot
-reads only — no server-initiated messages, no resource subscriptions.
-Session state lives in the coordinator, not the transport.
+The MCP app runs stateless (``stateless_http=True``) and answers in JSON
+(``json_response=True``): tools and one-shot reads only — no server-initiated
+messages, no resource subscriptions, so nothing needs an SSE stream. Session
+state lives in the coordinator, not the transport.
 
 Requires the ``runtime-tools`` extra (``mcp``, ``uvicorn``).
 """
@@ -121,8 +122,14 @@ def _build_mcp_app() -> FastMCP:
     Tool identity is per-request: the token router resolves which thread is
     calling and parks its registration in a context variable before handing
     the request to this app.
+
+    ``json_response=True`` answers each POST with one JSON object. The SSE
+    response path consults ``sse_starlette.sse.AppStatus.should_exit``, a
+    process-global latch set by any graceful uvicorn shutdown and never
+    cleared, after which every ``EventSourceResponse`` in the process closes
+    its writer before sending a body.
     """
-    mcp = FastMCP("ai_functions_runtime", stateless_http=True)
+    mcp = FastMCP("ai_functions_runtime", stateless_http=True, json_response=True)
 
     @mcp.tool(name="list_threads", description=LIST_THREADS_DESCRIPTION)
     async def list_threads() -> str:
@@ -245,6 +252,7 @@ class CoordinatorToolServer:
         self._by_thread: dict[ThreadId, str] = {}
         self._server: uvicorn.Server | None = None
         self._serve_task: asyncio.Task[None] | None = None
+        self._socket: socket.socket | None = None
         self._bound_port: int | None = None
 
     # ── Lifecycle ──
@@ -268,6 +276,7 @@ class CoordinatorToolServer:
 
         sock = self._bind_socket()
         bound_port = int(sock.getsockname()[1])
+        self._socket = sock
         self._bound_port = bound_port
 
         app = _TokenRouter(_build_mcp_app().streamable_http_app(), self)
@@ -283,7 +292,13 @@ class CoordinatorToolServer:
         deadline = asyncio.get_running_loop().time() + _STARTUP_TIMEOUT
         while not self._server.started:
             if self._serve_task.done():
-                self._serve_task.result()  # surface the startup failure
+                task = self._serve_task
+                self._server = None
+                self._serve_task = None
+                self._socket = None
+                self._bound_port = None
+                sock.close()
+                task.result()  # surface the startup failure
                 raise RuntimeError("tool server exited before startup completed")
             if asyncio.get_running_loop().time() >= deadline:
                 await self.stop()
@@ -299,19 +314,32 @@ class CoordinatorToolServer:
         on one (``send_message(mode="wait")``, say) sees the connection close
         mid-response.
 
+        Ensures:
+            - The listening socket is closed, so the port is free once this
+              returns.
+            - No later server in this process is affected by this one stopping.
+
         Concurrency:
             Idempotent; stopping a never-started server is a no-op.
         """
         self._registrations.clear()
         self._by_thread.clear()
-        server, task = self._server, self._serve_task
+        server, task, sock = self._server, self._serve_task, self._socket
         self._server = None
         self._serve_task = None
+        self._socket = None
         self._bound_port = None
         if server is None or task is None:
             return
+        # Must be uvicorn's graceful shutdown: cancelling the serving task
+        # instead leaves later servers in this process accepting connections
+        # they never answer.
         server.should_exit = True
         await task
+        # Also closed by uvicorn's shutdown; closing here covers a ``start``
+        # that gave up before serving began.
+        if sock is not None:
+            sock.close()
 
     @property
     def base_url(self) -> str:

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -394,8 +394,8 @@ async def test_post_condition_failure_rides_next_turn(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
-async def test_fork_resumes_a_distinct_codex_thread(tmp_path: Path) -> None:
-    """fork() returns a template resuming a server-side fork of the transcript."""
+async def test_fork_names_the_branch_point_without_creating_it(tmp_path: Path) -> None:
+    """fork() records what to branch from and issues no Codex RPC."""
     with MockModelServer() as model:
         model.enqueue(assistant_turn("first reply", response_id="r1"))
         template = CodexAgent(config=codex_test_config(tmp_path, model.url))
@@ -408,10 +408,53 @@ async def test_fork_resumes_a_distinct_codex_thread(tmp_path: Path) -> None:
 
             forked = await thread.fork()
             assert isinstance(forked, CodexAgent)
-            assert forked.resume_thread_id is not None
-            assert forked.resume_thread_id != source_id
+            assert forked.fork_of_thread_id == source_id
+            assert forked.resume_thread_id is None
+            assert thread.codex_thread_id == source_id
         finally:
             await thread.teardown()
+
+
+@pytest.mark.integration
+async def test_a_fork_and_its_source_run_independently(tmp_path: Path) -> None:
+    """Both sides of a fork stay writable.
+
+    Codex permits one writer per stored thread, so a fork must be created by the
+    app-server that will write to it rather than by the source's.
+    """
+    with MockModelServer() as model:
+        for i in range(1, 5):
+            model.enqueue(assistant_turn(f"reply {i}", response_id=f"r{i}"))
+
+        template = CodexAgent(config=codex_test_config(tmp_path, model.url))
+        coord = InMemoryCoordinator()
+        worker = await LocalWorker(coord).register()
+        source = await worker.spawn_locally(template, thread_name="source")
+        try:
+            _ = await asyncio.wait_for(source.run("REMEMBER-THIS"), timeout=120)
+
+            forked = await coord.fork(source.id)
+            try:
+                # The fork runs while the source is connected, and the source
+                # runs afterwards.
+                fork_reply = await asyncio.wait_for(forked.run("fork turn"), timeout=120)
+                assert fork_reply != ""
+                source_reply = await asyncio.wait_for(source.run("source turn"), timeout=120)
+                assert source_reply != ""
+
+                # Distinct Codex conversations, both carrying the pre-fork turn.
+                live_source = worker._threads[source.id]  # pyright: ignore[reportPrivateUsage]
+                live_fork = worker._threads[forked.id]  # pyright: ignore[reportPrivateUsage]
+                assert isinstance(live_source, CodexAgentThread)
+                assert isinstance(live_fork, CodexAgentThread)
+                assert live_fork.codex_thread_id != live_source.codex_thread_id
+                transcripts = " ".join(" ".join(model.user_texts(i)) for i in range(len(model.requests)))
+                assert transcripts.count("REMEMBER-THIS") >= 2
+            finally:
+                await forked.terminate_now()
+        finally:
+            await source.terminate_now()
+            await worker.close()
 
 
 @pytest.mark.integration

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -220,3 +220,56 @@ async def test_stop_is_idempotent() -> None:
     await srv.start()
     await srv.stop()
     await srv.stop()
+
+
+async def test_stop_frees_the_port() -> None:
+    """A stopped server's port is closed, not merely unrouted."""
+    srv = CoordinatorToolServer()
+    await srv.start()
+    base_url = srv.base_url
+    async with httpx.AsyncClient() as client:
+        assert (await client.post(f"{base_url}/mcp/unknown", json={})).status_code == 404
+    await srv.stop()
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(httpx.HTTPError):
+            _ = await client.post(f"{base_url}/mcp/unknown", json={}, timeout=5)
+
+
+async def test_successive_servers_keep_working() -> None:
+    """Stopping a server does not break the next one in this process.
+
+    ``sse-starlette`` latches a process-global flag off
+    ``uvicorn.Server.should_exit`` and never clears it, which disables every
+    later ``EventSourceResponse`` in the process. Four rounds cover the delay
+    between the first stop and the flag taking effect.
+    """
+    coord = _StubCoordinator()
+    for _ in range(4):
+        srv = CoordinatorToolServer()
+        await srv.start()
+        try:
+            reg = srv.register(coord, ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+            reply = await _call(reg.url, reg.token, "send_message", {"thread_id": "t-bob", "message": "x"})
+            assert "pong" in reply
+        finally:
+            await srv.stop()
+
+
+async def test_a_foreign_graceful_shutdown_does_not_break_the_server(
+    server: CoordinatorToolServer,
+) -> None:
+    """Another component's uvicorn shutdown does not disable these tools.
+
+    ``sse-starlette``'s latch is process-global, so an application serving its
+    own uvicorn app alongside a coordinator trips it. Setting the flag directly
+    stands in for that shutdown.
+    """
+    sse = pytest.importorskip("sse_starlette.sse")
+    reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
+    previous = sse.AppStatus.should_exit
+    sse.AppStatus.should_exit = True
+    try:
+        listing = await _call(reg.url, reg.token, "list_threads", {})
+        assert "t-bob" in listing
+    finally:
+        sse.AppStatus.should_exit = previous


### PR DESCRIPTION
Fixes two issues:
1. Stopping a Codex thread and then starting another fails to properly restart a new MCP server.
2. Forked Codex threads cannot be written to.

## 1. `fix(runtime): serve the runtime tools as JSON, not SSE`

`sse-starlette` latches a process-global `AppStatus.should_exit` off `uvicorn.Server.should_exit` and never clears it. Once any graceful uvicorn shutdown in the process sets it, every later `EventSourceResponse` closes its writer before sending a body.

`CodexAgentThread` starts and stops one `CoordinatorToolServer` per thread, so from the second thread on the app-server attached **no runtime tools at all**

`json_response=True` answers each POST with one JSON object — equally valid streamable HTTP, and these tools never stream — which keeps the server independent of that global. This resolves the issue.

Tests: four sequential start/call/stop rounds, a foreign shutdown latching the flag, port release after stop.

## 2. `fix(codex): let the forked thread's own app-server create the fork`

Codex allows one writer per stored thread: the app-server holding a thread owns its writer lock, and any other app-server asking to resume it is refused with `thread ... already has an active writer`. `fork()` created the fork through the *source's* client, taking that lock, then returned a template resuming it — so `Coordinator.fork` of a running Codex thread produced a thread that could not run until the source was torn down.

Behaviour measured directly against the SDK with two app-servers over one `CODEX_HOME`:

| | |
|---|---|
| source keeps running after being forked | works |
| forking app-server writes to its own fork | works |
| **another app-server resumes that fork** | **refused — active writer** |
| another app-server forks a source open elsewhere | works |
| that app-server writes to the fork it created | works |

Forking only reads the source, so `fork()` now records the branch point in `CodexAgent.fork_of_thread_id` and issues no RPC; `_ensure_connected` calls `thread/fork` from the app-server that will write to the result. Both sides then run independently, and spawning one forked template twice yields two independent forks.

Two documented consequences: the branch point is the source transcript as it stands when the fork *first connects* (`ThreadForkParams.lastTurnId` would pin it exactly, but `AsyncCodex.thread_fork` does not expose it), and the fork inherits the source's personality since fork takes no `personality` parameter.

Tests: the previous fork test only asserted the returned id differed and never ran the fork; it is replaced by one asserting `fork()` issues no RPC, plus one running both the fork and its source while both are live.

## Verification

- `ruff check`, `ruff format`, `stubtest` (79 modules) clean; spec stubs updated alongside the code.
- Full suite: 450 passed, 2 skipped. Two `tests/test_cli_commands.py` failures reproduce on unmodified `main` in the same environment and are unrelated.
- Codex integration tier (real `codex app-server`, mocked model) green, including the new fork test.
- Also exercised out of tree against real backends: the runtime tools over a real `mcp` client and a real coordinator (26 assertions), a Codex agent messaging a live Bedrock-backed `@ai_function` peer over HTTP MCP, and the shared post-condition loop on the real `claude` and `kiro-cli` binaries.