### PR TITLE
fix(cli): fixes compatibility with the latest version of `typer` and raise unusable dependency floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,19 +25,19 @@ classifiers = [
 ]
 
 dependencies = [
-    "strands-agents>=1.16.0",
+    "strands-agents>=1.24.0",
     "pydantic>=2.4.0,<3.0.0",
     "tstr>=0.4.0.post1",
     # The CLI (`ai-functions`) is built on the network layer and the
     # Typer/Rich/Textual stack, so these are runtime requirements.
     "websockets>=12.0",
     "cloudpickle>=3.0.0",
-    "typer>=0.12",
+    "typer>=0.18.0",
     "rich>=13.7",
     "textual>=0.70",
     "platformdirs>=4.0",
     # Memory/optimizer rendering serializes parameter values to YAML.
-    "pyyaml>=6.0",
+    "pyyaml>=6.0.1",
     "smolagents>=1.24.0",
     "rank-bm25>=0.2.2",
 ]
@@ -90,13 +90,13 @@ dependencies = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",
-    "hypothesis>=6.0",
+    "hypothesis>=6.92.0",
     "ruff>=0.1.0",
     "mypy>=1.20.0",
     "websockets>=12.0",
     "cloudpickle>=3.0.0",
     "claude-agent-sdk>=0.2.137",
-    "typer>=0.12",
+    "typer>=0.18.0",
     "rich>=13.7",
     "textual>=0.70",
     "platformdirs>=4.0",
@@ -104,7 +104,7 @@ dependencies = [
     "mcp>=1.29",
     "uvicorn>=0.30",
     "openai-codex>=0.144.4",
-    "pyyaml>=6.0",
+    "pyyaml>=6.0.1",
     "bedrock-agentcore>=1.6.0",
     "rank-bm25>=0.2.2",
     "smolagents>=1.24.0",

--- a/src/ai_functions/cli/__init__.py
+++ b/src/ai_functions/cli/__init__.py
@@ -67,15 +67,14 @@ def _usage_error_types() -> tuple[type[click.ClickException], ...]:
 
 
 def _abort_types() -> tuple[type[BaseException], ...]:
-    """Click ``Abort`` classes to translate in :func:`main` (see above)."""
-    types: list[type[BaseException]] = [click.Abort]
-    try:
-        from typer._click import exceptions as _vendored
+    """``Abort`` classes to translate in :func:`main`.
 
-        types.append(_vendored.Abort)
-    except ImportError:
-        pass
-    return tuple(types)
+    ``typer.Abort`` is a ``RuntimeError``, not a ``click.Abort`` subclass, so
+    both types are needed.
+    """
+    import typer
+
+    return (click.Abort, typer.Abort)
 
 
 def main() -> int:


### PR DESCRIPTION
Two dependency-driven breakages, one commit each.

## `fix(cli): catch the public typer.Abort`

`_abort_types()` read `Abort` off the vendored `typer._click.exceptions`, which
carried it only in typer 0.26.0–0.27.1. Typer 0.27.2 keeps `Abort` solely in
`typer.exceptions`, so building the tuple raises `AttributeError` — and since
that happens while evaluating an `except` clause, it replaces the usage error
being handled. Every CLI usage error (missing argument, unknown command, bad
option) exits with a traceback instead of the message and exit code 1 that
`main()` documents under `Ensures: Never raises`.

`typer.Abort` is public, present across the whole supported range, and is what
the vendored click raises (`typer/_click/core.py` imports it from
`..exceptions`). It is a `RuntimeError`, not a `click.Abort` subclass, so both
types are needed.

This is what fails CI on `main`:

    FAILED tests/test_cli_commands.py::test_main_missing_argument_exits_one_without_traceback
    FAILED tests/test_cli_commands.py::test_main_unknown_command_exits_one_without_traceback
    AttributeError: module 'typer._click.exceptions' has no attribute 'Abort'

## `fix(deps): raise floors that cannot satisfy requires-python >= 3.12`

Installing the declared floors yields an environment that cannot import the
package or run the CLI:

| declared | failure on Python 3.12 | new floor |
|---|---|---|
| `strands-agents>=1.16.0` | no `strands.tools.ToolProvider`; `ai_functions.codex` fails to import, so 25 test modules error at collection | `>=1.24.0` |
| `typer>=0.12` | with click 8.2+, usage errors return exit 2, breaking `main()`'s contract; below 0.12.5 the CLI's `str \| None` annotations are rejected outright (`RuntimeError: Type not yet supported`) | `>=0.18.0` |
| `pyyaml>=6.0` | no cp312 wheel; sdist fails to build against Cython 3 | `>=6.0.1` |
| `hypothesis>=6.0` (dev env) | calls `EntryPoints.get`, removed in 3.12 | `>=6.92.0` |

typer 0.18.0 is the first release whose usage errors still exit 1 against a
modern click; `click` is imported directly by `ai_functions.cli` but not
declared, so it resolves to the latest release.

## Verification

Full suite on both ends of the supported range, on Python 3.12:

| | typer | click | pytest | strands-agents | result |
|---|---|---|---|---|---|
| current | 0.27.2 | 8.5.0 | 9.1.1 | 1.54.0 | 448 passed, 2 skipped |
| floors (`uv pip install --resolution lowest-direct`) | 0.18.0 | 8.5.0 | 7.0.0 | 1.24.0 | 448 passed, 2 skipped |

The floor environment also covers the other side of the typer split: 0.18.0
predates the vendored `typer._click`, so `_usage_error_types()`'s `ImportError`
branch is the live path there, while 0.27.2 has the vendored module without
`Abort`.