### PR TITLE
ci(release): bump gh-action-pypi-publish to v1.14.2

### DIFF
--- a/.github/workflows/pypi-publish-on-release.yml
+++ b/.github/workflows/pypi-publish-on-release.yml
@@ -73,4 +73,4 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
The pinned image dated 2026-02-18 ships twine 6.x, whose `twine check` rejects `Metadata-Version: 2.5` as invalid. hatchling 1.32.0 declares 2.5, so publishing v0.4.0 failed with

    InvalidDistribution: Invalid distribution metadata: '2.5' is not a
    valid metadata version

v1.14.2 pins twine 7.0.0, which accepts it. PyPI already serves 2.5 distributions, including hatchling 1.32.0's own wheel.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
