### PR TITLE
fix(runtime): run the tool server on mcp 1.x or 2.x, widen the pin to mcp<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,14 +59,14 @@ agentcore = [
     "bedrock-agentcore>=1.6.0",
 ]
 runtime-tools = [
-    "mcp>=1.29",
+    "mcp>=1.29,<3",
     "uvicorn>=0.30",
 ]
 codex = [
     "openai-codex>=0.147.0",
     # The Codex thread serves the runtime tools to the app-server over HTTP
     # MCP (CoordinatorToolServer), so the runtime-tools deps come along.
-    "mcp>=1.29",
+    "mcp>=1.29,<3",
     "uvicorn>=0.30",
 ]
 
@@ -101,7 +101,7 @@ dependencies = [
     "textual>=0.70",
     "platformdirs>=4.0",
     "agent-client-protocol>=0.12.1,<0.13",
-    "mcp>=1.29",
+    "mcp>=1.29,<3",
     "uvicorn>=0.30",
     "openai-codex>=0.147.0",
     "pyyaml>=6.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ runtime-tools = [
     "uvicorn>=0.30",
 ]
 codex = [
-    "openai-codex>=0.144.4",
+    "openai-codex>=0.147.0",
     # The Codex thread serves the runtime tools to the app-server over HTTP
     # MCP (CoordinatorToolServer), so the runtime-tools deps come along.
     "mcp>=1.29",
@@ -103,7 +103,7 @@ dependencies = [
     "agent-client-protocol>=0.12.1,<0.13",
     "mcp>=1.29",
     "uvicorn>=0.30",
-    "openai-codex>=0.144.4",
+    "openai-codex>=0.147.0",
     "pyyaml>=6.0.1",
     "bedrock-agentcore>=1.6.0",
     "rank-bm25>=0.2.2",

--- a/spec/ai_functions/runtime/tool_server.pyi
+++ b/spec/ai_functions/runtime/tool_server.pyi
@@ -23,6 +23,8 @@ The MCP app runs stateless (``stateless_http=True``) and answers in JSON
 (``json_response=True``): tools and one-shot reads only — no server-initiated
 messages, no resource subscriptions, so nothing needs an SSE stream.
 
+Runs on either major of the ``mcp`` SDK (1.x ``FastMCP`` or 2.x ``MCPServer``).
+
 Requires the ``runtime-tools`` extra (``mcp``, ``uvicorn``).
 """
 

--- a/src/ai_functions/runtime/tool_server.py
+++ b/src/ai_functions/runtime/tool_server.py
@@ -34,6 +34,12 @@ The MCP app runs stateless (``stateless_http=True``) and answers in JSON
 messages, no resource subscriptions, so nothing needs an SSE stream. Session
 state lives in the coordinator, not the transport.
 
+Runs on either major of the ``mcp`` SDK. mcp 2 renamed ``FastMCP`` to
+``MCPServer`` (``mcp.server.mcpserver``) and moved the transport options
+(``stateless_http``, ``json_response``) from the constructor to
+``streamable_http_app()``; the import below picks whichever is installed and
+:func:`_build_mcp_app` places the options accordingly.
+
 Requires the ``runtime-tools`` extra (``mcp``, ``uvicorn``).
 """
 
@@ -60,7 +66,15 @@ from .coordinator_tools_core import send_message as _core_send_message
 
 try:
     import uvicorn
-    from mcp.server.fastmcp import FastMCP
+
+    try:
+        from mcp.server.mcpserver import MCPServer as _MCPServer  # mcp >= 2
+    except ImportError:
+        from mcp.server.fastmcp import FastMCP as _MCPServer  # mcp 1.x
+
+        _MCP_V2 = False
+    else:
+        _MCP_V2 = True
 except ImportError as exc:  # pragma: no cover - exercised only without the extra
     raise ImportError(
         "CoordinatorToolServer requires the optional 'runtime-tools' extra "
@@ -116,8 +130,31 @@ def _require_registration() -> _Registration:
     return reg
 
 
-def _build_mcp_app() -> FastMCP:
-    """Build the single stateless FastMCP app serving both runtime tools.
+def _new_mcp_server() -> _MCPServer:
+    """Construct the MCP server object for the installed ``mcp`` major.
+
+    mcp 1.x takes the transport options on the constructor; mcp 2 takes them
+    on :meth:`streamable_http_app` (see :func:`_streamable_http_app`).
+    """
+    if _MCP_V2:
+        return _MCPServer("ai_functions_runtime")
+    return _MCPServer("ai_functions_runtime", stateless_http=True, json_response=True)
+
+
+def _streamable_http_app(mcp: _MCPServer) -> Callable[..., Awaitable[None]]:
+    """Return ``mcp``'s streamable-HTTP ASGI app, stateless and answering in JSON.
+
+    ``stateless_http=True`` / ``json_response=True`` are constructor arguments
+    on mcp 1.x (already applied by :func:`_new_mcp_server`) and
+    ``streamable_http_app`` arguments on mcp 2.
+    """
+    if _MCP_V2:
+        return mcp.streamable_http_app(stateless_http=True, json_response=True)
+    return mcp.streamable_http_app()
+
+
+def _build_mcp_app() -> Callable[..., Awaitable[None]]:
+    """Build the single stateless MCP ASGI app serving both runtime tools.
 
     Tool identity is per-request: the token router resolves which thread is
     calling and parks its registration in a context variable before handing
@@ -129,7 +166,7 @@ def _build_mcp_app() -> FastMCP:
     cleared, after which every ``EventSourceResponse`` in the process closes
     its writer before sending a body.
     """
-    mcp = FastMCP("ai_functions_runtime", stateless_http=True, json_response=True)
+    mcp = _new_mcp_server()
 
     @mcp.tool(name="list_threads", description=LIST_THREADS_DESCRIPTION)
     async def list_threads() -> str:
@@ -146,7 +183,7 @@ def _build_mcp_app() -> FastMCP:
         reg = _require_registration()
         return await _core_send_message(reg.coordinator, str(reg.thread_id), thread_id, message, mode)
 
-    return mcp
+    return _streamable_http_app(mcp)
 
 
 async def _plain_response(send: _Send, status: int, body: str) -> None:
@@ -169,7 +206,7 @@ async def _plain_response(send: _Send, status: int, body: str) -> None:
 class _TokenRouter:
     """Pure-ASGI wrapper enforcing the token and Host checks per request.
 
-    Wraps the FastMCP app rather than subclassing any framework middleware so
+    Wraps the MCP ASGI app rather than subclassing any framework middleware so
     the inner app's lifespan passes through untouched (the streamable-HTTP
     session manager initialises in the lifespan; dropping it breaks every
     request).
@@ -205,7 +242,7 @@ class _TokenRouter:
             await _plain_response(send, 401, "unauthorized")
             return
 
-        # Rewrite to the path the FastMCP app is mounted on.
+        # Rewrite to the path the MCP app is mounted on.
         scope["path"] = "/mcp" + (f"/{rest}" if rest else "")
         ctx_token = _active_registration.set(registration)
         try:
@@ -279,7 +316,7 @@ class CoordinatorToolServer:
         self._socket = sock
         self._bound_port = bound_port
 
-        app = _TokenRouter(_build_mcp_app().streamable_http_app(), self)
+        app = _TokenRouter(_build_mcp_app(), self)
         config = uvicorn.Config(
             app,
             host=_HOST,

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -9,6 +9,8 @@ required in both the path and the header, and revocation is immediate.
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from collections.abc import AsyncIterator
 from typing import Any
 
 import httpx
@@ -71,9 +73,19 @@ def _http(token: str) -> httpx.AsyncClient:
     return httpx.AsyncClient(headers={"Authorization": f"Bearer {token}"})
 
 
+@contextlib.asynccontextmanager
+async def _streams(url: str, token: str) -> AsyncIterator[tuple[Any, Any]]:  # pyright: ignore[reportExplicitAny]
+    """Open the streamable-HTTP transport and yield ``(read, write)``.
+
+    mcp 1.x yields a third value (the session-id getter); mcp 2 yields two.
+    """
+    async with streamable_http_client(url, http_client=_http(token)) as streams:
+        yield streams[0], streams[1]
+
+
 async def _call(url: str, token: str, tool: str, args: dict[str, Any]) -> str:  # pyright: ignore[reportExplicitAny]
     """Open a session against ``url`` and invoke one tool."""
-    async with streamable_http_client(url, http_client=_http(token)) as (read, write, _):
+    async with _streams(url, token) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             result = await session.call_tool(tool, args)
@@ -93,13 +105,15 @@ async def server():  # noqa: ANN201 - pytest fixture
 async def test_tools_and_schema_match_the_shared_core(server: CoordinatorToolServer) -> None:
     """The wire schema is the shared declaration: enum, default, required."""
     reg = server.register(_StubCoordinator(), ThreadId("t-alice"))  # pyright: ignore[reportArgumentType]
-    async with streamable_http_client(reg.url, http_client=_http(reg.token)) as (read, write, _):
+    async with _streams(reg.url, reg.token) as (read, write):
         async with ClientSession(read, write) as session:
             await session.initialize()
             tools = {t.name: t for t in (await session.list_tools()).tools}
 
     assert set(tools) == {"list_threads", "send_message"}
-    schema = tools["send_message"].inputSchema
+    # Wire-name lookup: the field is ``inputSchema`` on mcp 1.x and ``input_schema``
+    # (alias ``inputSchema``) on mcp 2.
+    schema = tools["send_message"].model_dump(by_alias=True)["inputSchema"]
     core = SEND_MESSAGE_INPUT_SCHEMA["properties"]
     assert schema["properties"]["mode"]["enum"] == core["mode"]["enum"]
     assert schema["properties"]["mode"]["default"] == core["mode"]["default"]


### PR DESCRIPTION
## What changed

- `src/ai_functions/runtime/tool_server.py` runs on either major of the `mcp` SDK. It imports `MCPServer` from `mcp.server.mcpserver` (mcp 2) and falls back to `FastMCP` from `mcp.server.fastmcp` (mcp 1.x). The transport options `stateless_http=True` / `json_response=True` go on the constructor under 1.x and on `streamable_http_app()` under 2.x, where they moved. `_build_mcp_app()` now returns the ASGI app; the public `CoordinatorToolServer` API is unchanged.
- `spec/ai_functions/runtime/tool_server.pyi`: docstring notes both majors. No signature changes.
- `pyproject.toml`: `mcp>=1.29,<3` in the `runtime-tools` and `codex` extras and the default hatch env (was `mcp>=1.29`). The `codex` extra floor moves to `openai-codex>=0.147.0` (current release is 0.154.0).
- `tests/test_tool_server.py` reads the two client-visible differences through one helper: `streamable_http_client` yields two streams on 2.x (three on 1.x), and `Tool.inputSchema` became `Tool.input_schema` with wire alias `inputSchema`, so the test reads `model_dump(by_alias=True)["inputSchema"]`.

## Why

A fresh install of `main` with the `runtime-tools` extra resolves `mcp>=1.29` to 2.x, and the tool server cannot import. Reproduced on 2026-09-11 in a clean venv (`uv venv`, Python 3.12, `pip install -e '.[runtime-tools]'` at `8902c55f`):

```
$ python -c "import importlib.metadata as m; print('mcp', m.version('mcp'))"
mcp 2.1.1
$ python -c "import ai_functions.runtime.tool_server"
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was
renamed to MCPServer (from mcp.server.mcpserver import MCPServer) and other APIs changed; see the
migration guide at https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver
or pin 'mcp<2' to keep running v1 code.

The above exception was the direct cause of the following exception:
  File ".../src/ai_functions/runtime/tool_server.py", line 65, in <module>
    raise ImportError(
ImportError: CoordinatorToolServer requires the optional 'runtime-tools' extra ...
```

Every `CoordinatorToolServer` user (the Codex thread among them) hit this on install since mcp 2.0.0 shipped. Pinning `<2` would fix the install but would conflict with anything else in an environment that has already moved to mcp 2; supporting both majors keeps the extra installable either way.

## Compatibility approach

One import site decides the major (`_MCP_V2`), and two small helpers (`_new_mcp_server`, `_streamable_http_app`) place the transport options where the installed major accepts them. Everything else in the module (the token router, registrations, the `@mcp.tool` decorators, `streamable_http_app()`) is the same call on both majors. No behaviour change under 1.x.

Note on the upper end of the range: `strands-agents>=1.24.0` (a base dependency) pins `mcp<2.2`, so the default environment resolves to 2.1.1 today; 2.2.x becomes reachable once that pin moves. The tool-server tests were also run against `mcp==2.2.0` installed directly (15 passed).

## Tests

`tests/test_tool_server.py` (15 tests) exercises tool listing and schema, per-registration identity, dispatch, token rotation and revocation, Host and bearer checks, successive servers, and the sse-starlette shutdown latch. All 15 pass under mcp 1.30.0, 2.1.1 and 2.2.0.

## Gate on the pushed branch (`cd3dd8dc`)

Under mcp 2.1.1 (default resolution):

```
hatch run ruff format --check src tests   -> 3 files would be reformatted (same three as main:
                                             experimental/economics/function.py, memory/base.py, tests/test_economics.py)
hatch run lint                            -> All checks passed!
hatch run check-spec                      -> Success: no issues found in 79 modules
hatch run test -- -q -p no:cacheprovider  -> 453 passed, 2 skipped
```

Under mcp 1.30.0 (same env, `mcp==1.30.0` installed):

```
hatch run ruff format --check src tests   -> same 3 pre-existing files
hatch run lint                            -> All checks passed!
hatch run check-spec                      -> Success: no issues found in 79 modules
hatch run test -- -q -p no:cacheprovider  -> 453 passed, 2 skipped
```
