### PR TITLE
feat(network): ErrorFrame carries an ErrorKind so callers stop matching remote exception names

### DIFF
--- a/spec/ai_functions/network/__init__.pyi
+++ b/spec/ai_functions/network/__init__.pyi
@@ -10,7 +10,10 @@ to a server-side :class:`~ai_functions.runtime.coordinator.InMemoryCoordinator`.
   by proxying every method over the wire.
 - :class:`WireChannel` — symmetric bidirectional RPC machinery used by
   both sides.
-- Frame models live in :mod:`ai_functions.network.wire`.
+- Frame models live in :mod:`ai_functions.network.wire`; the
+  :data:`ErrorKind` classification a host extends with
+  :func:`register_error_kind` lives in
+  :mod:`ai_functions.network.error_kinds`.
 
 See the module-level docstrings for design details.
 """
@@ -20,12 +23,14 @@ from __future__ import annotations
 from .channel import WireChannel
 from .client import CoordinatorClient
 from .endpoint import CoordinatorEndpoint
+from .error_kinds import classify, register_error_kind
 from .wire import (
     CallFrame,
     ConnectionClosedError,
     DEFAULT_HOST,
     DEFAULT_PORT,
     ErrorFrame,
+    ErrorKind,
     EventFrame,
     Frame,
     RemoteError,
@@ -42,6 +47,7 @@ __all__ = [
     "DEFAULT_HOST",
     "DEFAULT_PORT",
     "ErrorFrame",
+    "ErrorKind",
     "EventFrame",
     "Frame",
     "RemoteError",
@@ -49,4 +55,6 @@ __all__ = [
     "Transport",
     "WireChannel",
     "WireError",
+    "classify",
+    "register_error_kind",
 ]

--- a/spec/ai_functions/network/channel.pyi
+++ b/spec/ai_functions/network/channel.pyi
@@ -28,7 +28,8 @@ Handler = Callable[[dict[str, Any]], Awaitable[Any]]  # pyright: ignore[reportEx
 
 Raising an exception produces an ``ErrorFrame`` in response; the
 exception's class name becomes the frame ``type``, ``str(exc)`` becomes
-the ``message``.
+the ``message``, and :func:`ai_functions.network.error_kinds.classify`
+supplies the ``error_kind``.
 """
 
 EventCallback = Callable[[Event], None]

--- a/spec/ai_functions/network/error_kinds.pyi
+++ b/spec/ai_functions/network/error_kinds.pyi
@@ -1,0 +1,65 @@
+"""Exception-to-:data:`~ai_functions.network.wire.ErrorKind` classification registry.
+
+An ``ErrorFrame`` carries the peer's exception class *name*, which is all a
+different process can send. A caller that must decide retry-versus-abort from
+that name ends up matching strings — ``"ThrottlingException"``, a ``"botocore."``
+prefix, ``"ValidationException" in name`` — and every such match breaks when a
+provider renames or wraps an exception. :func:`classify` answers the same
+question from the exception's type, and :func:`register_error_kind` lets the host
+that owns a model provider or storage client declare that provider's exceptions
+once, at the process that raises them, where the real class is in scope.
+
+Registration is process-wide and applies to the whole MRO of the registered
+type, so registering a provider's base exception classifies every subclass.
+
+Usage::
+
+    from botocore.exceptions import ClientError
+    from ai_functions.network import register_error_kind
+
+    register_error_kind(ClientError, "model_unavailable")
+
+This module keeps :mod:`ai_functions.network.wire` free of runtime imports: the
+frame schemas stay transport- and runtime-agnostic while the seed registry here
+names the runtime's own error classes.
+
+Invariants:
+    A. ``classify`` is total — every ``BaseException`` maps to some
+       ``ErrorKind``, defaulting to ``"internal"``, so a caller never has to
+       handle "unclassified".
+    B. The most derived registered ancestor wins, so registering a base class
+       never overrides a more specific registration for a subclass.
+"""
+
+from __future__ import annotations
+
+from .wire import ErrorKind
+
+
+def classify(exc: BaseException) -> ErrorKind:
+    """Classify ``exc`` by walking its MRO against the registry.
+
+    Args:
+        exc: The exception a peer is about to report, or reported.
+
+    Returns:
+        The kind registered for the most derived class in ``type(exc).__mro__``
+        that has one; ``"internal"`` when none does.
+    """
+    ...
+
+
+def register_error_kind(exc_type: type[BaseException], kind: ErrorKind) -> None:
+    """Declare that ``exc_type`` and its subclasses classify as ``kind``.
+
+    Call this once at process start for every third-party exception whose class
+    the wire layer cannot know: a model provider's throttling and access errors
+    (``model_unavailable``), a storage client's missing-key error
+    (``not_found``). The registration replaces any previous one for the same
+    type and shadows registrations for its base classes.
+
+    Args:
+        exc_type: Exception class to classify.
+        kind: The classification a caller should see for it.
+    """
+    ...

--- a/spec/ai_functions/network/error_kinds.pyi
+++ b/spec/ai_functions/network/error_kinds.pyi
@@ -1,16 +1,21 @@
-"""Exception-to-:data:`~ai_functions.network.wire.ErrorKind` classification registry.
+"""Exception-to-:data:`~ai_functions.network.wire.ErrorKind` classification.
 
-An ``ErrorFrame`` carries the peer's exception class *name*, which is all a
-different process can send. A caller that must decide retry-versus-abort from
-that name ends up matching strings — ``"ThrottlingException"``, a ``"botocore."``
-prefix, ``"ValidationException" in name`` — and every such match breaks when a
-provider renames or wraps an exception. :func:`classify` answers the same
-question from the exception's type, and :func:`register_error_kind` lets the host
-that owns a model provider or storage client declare that provider's exceptions
-once, at the process that raises them, where the real class is in scope.
+:func:`classify` maps an exception to the :data:`ErrorKind` a peer reads on the
+``ErrorFrame`` that reports it, so callers branch on the kind instead of
+matching the peer's exception class name.
 
-Registration is process-wide and applies to the whole MRO of the registered
-type, so registering a provider's base exception classifies every subclass.
+Two sources feed the classification, checked per class along the MRO:
+
+- An ``error_kind`` class attribute, declared by exception classes this
+  codebase owns (the runtime errors in :mod:`ai_functions.runtime.errors`,
+  :class:`~ai_functions.network.wire.ConnectionClosedError`).
+- A process-wide registry for third-party classes: :func:`register_error_kind`
+  lets the host that owns a model provider or storage client declare that
+  provider's exceptions once. Registration is last-write-wins across the whole
+  process.
+
+Both apply to the whole MRO, so declaring or registering a base exception
+classifies every subclass.
 
 Usage::
 
@@ -19,16 +24,14 @@ Usage::
 
     register_error_kind(ClientError, "model_unavailable")
 
-This module keeps :mod:`ai_functions.network.wire` free of runtime imports: the
-frame schemas stay transport- and runtime-agnostic while the seed registry here
-names the runtime's own error classes.
-
 Invariants:
     A. ``classify`` is total — every ``BaseException`` maps to some
        ``ErrorKind``, defaulting to ``"internal"``, so a caller never has to
        handle "unclassified".
-    B. The most derived registered ancestor wins, so registering a base class
-       never overrides a more specific registration for a subclass.
+    B. The most derived classified ancestor wins, so registering or declaring
+       a base class never overrides a more specific classification for a
+       subclass. At the same MRO level a registration wins over the class's
+       own declaration.
 """
 
 from __future__ import annotations
@@ -36,15 +39,29 @@ from __future__ import annotations
 from .wire import ErrorKind
 
 
+def coerce_error_kind(value: str | None) -> ErrorKind:
+    """Read a wire ``error_kind`` value into this build's vocabulary.
+
+    Args:
+        value: The frame's ``error_kind``; ``None`` from a peer that sends none.
+
+    Returns:
+        ``value`` when it is one of this build's :data:`ErrorKind` values,
+        ``"internal"`` otherwise.
+    """
+    ...
+
+
 def classify(exc: BaseException) -> ErrorKind:
-    """Classify ``exc`` by walking its MRO against the registry.
+    """Classify ``exc`` by walking its MRO against the registry and declarations.
 
     Args:
         exc: The exception a peer is about to report, or reported.
 
     Returns:
-        The kind registered for the most derived class in ``type(exc).__mro__``
-        that has one; ``"internal"`` when none does.
+        The kind registered or declared (``error_kind`` class attribute) for
+        the most derived class in ``type(exc).__mro__`` that has one;
+        ``"internal"`` when none does.
     """
     ...
 
@@ -55,8 +72,9 @@ def register_error_kind(exc_type: type[BaseException], kind: ErrorKind) -> None:
     Call this once at process start for every third-party exception whose class
     the wire layer cannot know: a model provider's throttling and access errors
     (``model_unavailable``), a storage client's missing-key error
-    (``not_found``). The registration replaces any previous one for the same
-    type and shadows registrations for its base classes.
+    (``not_found``). The registry is process-wide: the registration replaces any
+    previous one for the same type — last write wins — and shadows
+    registrations or declarations on its base classes.
 
     Args:
         exc_type: Exception class to classify.

--- a/spec/ai_functions/network/wire.pyi
+++ b/spec/ai_functions/network/wire.pyi
@@ -29,7 +29,7 @@ via a thin adapter.
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Protocol, runtime_checkable
+from typing import Annotated, Any, ClassVar, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
@@ -69,7 +69,10 @@ ErrorKind = Literal[
 A caller decides retry, escalate or abort from this value, so a peer's exception
 class name never has to be string-matched. The names an
 :class:`ai_functions.network.error_kinds` registry maps to each kind are the
-host's to extend; the vocabulary itself is closed:
+host's to extend. On the wire the field is an open string; a kind outside this
+vocabulary is read as ``"internal"``
+(:func:`~ai_functions.network.error_kinds.coerce_error_kind`). The values a
+reader can branch on:
 
 - ``cancelled`` — the remote work was cancelled cooperatively.
 - ``not_found`` — the named thread, worker or record does not exist there.
@@ -133,15 +136,15 @@ class ErrorFrame(BaseModel):
             :class:`RemoteError`.
         message: Human-readable error description.
         error_kind: Classification of the failure (see :data:`ErrorKind`).
-            Defaults to ``None``, which a reader treats as ``"internal"``, so a
-            peer that sends no classification still produces a valid frame.
+            ``None`` and values outside this build's :data:`ErrorKind`
+            vocabulary are read as ``"internal"``.
     """
 
     kind: Literal["error"]
     id: str
     type: str
     message: str
-    error_kind: ErrorKind | None
+    error_kind: str | None
 
 
 class EventFrame(BaseModel):
@@ -243,4 +246,11 @@ class RemoteError(WireError):
 
 
 class ConnectionClosedError(WireError):
-    """The peer connection closed before a pending call resolved."""
+    """This process's own connection closed before a pending call resolved.
+
+    Never rehydrated from a peer's ``ErrorFrame``: a peer's
+    ``ConnectionClosedError`` arrives as a :class:`RemoteError` with
+    ``kind == "connection_lost"``.
+    """
+
+    error_kind: ClassVar[ErrorKind]

--- a/spec/ai_functions/network/wire.pyi
+++ b/spec/ai_functions/network/wire.pyi
@@ -10,7 +10,9 @@ Frames are discriminated on ``kind``:
 - ``call``  — request: method name + JSON params. Awaits a ``result``
   or ``error`` frame with matching ``id``.
 - ``result`` — success response; carries a JSON value.
-- ``error``  — failure response; carries an error type + message.
+- ``error``  — failure response; carries an error type, a message and an
+  :data:`ErrorKind` classification the caller can branch on without
+  matching the peer's exception class name.
 - ``event``  — server-initiated event broadcast; no response expected.
 
 A single ``Binary`` field is used for cloudpickle payloads (Spawnables,
@@ -47,6 +49,37 @@ Binary = Annotated[bytes, ...]
 
 Used for cloudpickle-serialized spawnables and prompt args / kwargs /
 results — payloads that can't round-trip through JSON natively.
+"""
+
+
+# ── Error classification ─────────────────────────────────────────────────────
+
+ErrorKind = Literal[
+    "cancelled",
+    "not_found",
+    "terminated",
+    "invalid_input",
+    "model_unavailable",
+    "worker_lost",
+    "connection_lost",
+    "internal",
+]
+"""Transport-independent class of a remote failure, carried on every ``ErrorFrame``.
+
+A caller decides retry, escalate or abort from this value, so a peer's exception
+class name never has to be string-matched. The names an
+:class:`ai_functions.network.error_kinds` registry maps to each kind are the
+host's to extend; the vocabulary itself is closed:
+
+- ``cancelled`` — the remote work was cancelled cooperatively.
+- ``not_found`` — the named thread, worker or record does not exist there.
+- ``terminated`` — the thread existed and is gone; retrying the same id cannot work.
+- ``invalid_input`` — the call's arguments are wrong; retrying them cannot work.
+- ``model_unavailable`` — a model provider refused or throttled the call; retry later.
+- ``worker_lost`` — the worker hosting the thread died.
+- ``connection_lost`` — the transport dropped; the call's outcome is unknown.
+- ``internal`` — anything unclassified, which is the default a peer that sends no
+  ``kind`` at all is read as.
 """
 
 
@@ -99,12 +132,16 @@ class ErrorFrame(BaseModel):
             typed exception when possible; otherwise surfaced as
             :class:`RemoteError`.
         message: Human-readable error description.
+        error_kind: Classification of the failure (see :data:`ErrorKind`).
+            Defaults to ``None``, which a reader treats as ``"internal"``, so a
+            peer that sends no classification still produces a valid frame.
     """
 
     kind: Literal["error"]
     id: str
     type: str
     message: str
+    error_kind: ErrorKind | None
 
 
 class EventFrame(BaseModel):
@@ -181,20 +218,28 @@ class WireError(Exception):
 class RemoteError(WireError):
     """A peer returned an ``ErrorFrame`` whose ``type`` we cannot rehydrate.
 
+    ``kind`` is what a caller branches on: the local process has no class for
+    ``remote_type``, so classifying the failure by name is the only alternative
+    and it breaks the moment the peer renames or wraps an exception.
+
     Attributes:
         remote_type (str): The ``type`` field from the ErrorFrame — the
             peer's exception class name.
         message (str): The ``message`` field from the ErrorFrame.
+        kind (ErrorKind): Classification of the failure; ``"internal"`` for a
+            peer that sent no ``error_kind``.
 
     Args:
         remote_type: The ``type`` field from the ErrorFrame.
         message: The ``message`` field from the ErrorFrame.
+        kind: The frame's ``error_kind``, or ``"internal"`` when it carried none.
     """
 
     remote_type: str
     message: str
+    kind: ErrorKind
 
-    def __init__(self, remote_type: str, message: str) -> None: ...
+    def __init__(self, remote_type: str, message: str, kind: ErrorKind = "internal") -> None: ...
 
 
 class ConnectionClosedError(WireError):

--- a/spec/ai_functions/runtime/errors.pyi
+++ b/spec/ai_functions/runtime/errors.pyi
@@ -1,8 +1,13 @@
-"""Errors specific to runtime execution: dispatcher and distributed transport."""
+"""Errors specific to runtime execution: dispatcher and distributed transport.
+
+Each error declares an ``error_kind`` class attribute — the
+:data:`~ai_functions.network.wire.ErrorKind` value a peer reads when the error
+crosses the wire (see :func:`ai_functions.network.error_kinds.classify`).
+"""
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import ClassVar, Literal
 
 from ..types import EventKind, ThreadId, WorkerId
 
@@ -25,6 +30,7 @@ class ThreadIdMismatchError(ValueError):
         that matches the thread whose log they live in.
     """
 
+    error_kind: ClassVar[str]
     event_thread_id: ThreadId
     routing_thread_id: ThreadId
 
@@ -55,6 +61,7 @@ class EventEmissionError(RuntimeError):
         I5, I7.
     """
 
+    error_kind: ClassVar[str]
     kind: EventKind
     thread_id: ThreadId
     source: Literal["runtime", "thread"]
@@ -78,6 +85,7 @@ class ThreadNotFoundError(KeyError):
         thread_id: The id that was not found.
     """
 
+    error_kind: ClassVar[str]
     thread_id: ThreadId
 
     def __init__(self, thread_id: ThreadId) -> None: ...
@@ -95,6 +103,7 @@ class WorkerLostError(DistributedError):
         thread_ids: Ids of threads previously hosted on this worker.
     """
 
+    error_kind: ClassVar[str]
     worker_id: WorkerId
     thread_ids: list[ThreadId]
 
@@ -109,6 +118,7 @@ class SerializationError(DistributedError):
         reason: Cloudpickle error text.
     """
 
+    error_kind: ClassVar[str]
     function_name: str
 
     def __init__(self, function_name: str, reason: str) -> None: ...
@@ -122,6 +132,7 @@ class ConnectionLostError(DistributedError):
         retries: Number of failed reconnection attempts.
     """
 
+    error_kind: ClassVar[str]
     url: str
     retries: int
 

--- a/src/ai_functions/network/__init__.py
+++ b/src/ai_functions/network/__init__.py
@@ -10,7 +10,10 @@ to a server-side :class:`~ai_functions.runtime.coordinator.InMemoryCoordinator`.
   by proxying every method over the wire.
 - :class:`WireChannel` — symmetric bidirectional RPC machinery used by
   both sides.
-- Frame models live in :mod:`ai_functions.network.wire`.
+- Frame models live in :mod:`ai_functions.network.wire`; the
+  :data:`ErrorKind` classification a host extends with
+  :func:`register_error_kind` lives in
+  :mod:`ai_functions.network.error_kinds`.
 
 See the module-level docstrings for design details.
 """
@@ -20,12 +23,14 @@ from __future__ import annotations
 from .channel import WireChannel
 from .client import CoordinatorClient
 from .endpoint import CoordinatorEndpoint
+from .error_kinds import classify, register_error_kind
 from .wire import (
     DEFAULT_HOST,
     DEFAULT_PORT,
     CallFrame,
     ConnectionClosedError,
     ErrorFrame,
+    ErrorKind,
     EventFrame,
     Frame,
     RemoteError,
@@ -42,6 +47,7 @@ __all__ = [
     "DEFAULT_HOST",
     "DEFAULT_PORT",
     "ErrorFrame",
+    "ErrorKind",
     "EventFrame",
     "Frame",
     "RemoteError",
@@ -49,4 +55,6 @@ __all__ = [
     "Transport",
     "WireChannel",
     "WireError",
+    "classify",
+    "register_error_kind",
 ]

--- a/src/ai_functions/network/channel.py
+++ b/src/ai_functions/network/channel.py
@@ -27,12 +27,11 @@ from pydantic import TypeAdapter
 
 from ..runtime.errors import DistributedError, ThreadNotFoundError
 from ..types import Event
-from .error_kinds import classify
+from .error_kinds import classify, coerce_error_kind
 from .wire import (
     CallFrame,
     ConnectionClosedError,
     ErrorFrame,
-    ErrorKind,
     EventFrame,
     Frame,
     RemoteError,
@@ -90,6 +89,11 @@ def _describe_transport_close(exc: BaseException) -> tuple[str, bool]:
 # kind/thread/source) cannot be rebuilt from a message without inventing those
 # fields, so it stays out of this table and reaches the caller as a RemoteError
 # whose ``kind`` classifies it. Unknown names produce a RemoteError too.
+# ConnectionClosedError stays out on purpose even though it is constructible
+# from a message: it means *this* process's transport closed, and rehydrating a
+# peer's would make a remote drop indistinguishable from a local one — exactly
+# the distinction reconnect logic branches on. A peer's arrives as a
+# RemoteError with kind "connection_lost".
 _KNOWN_EXCEPTIONS: dict[str, type[Exception]] = {
     "ValueError": ValueError,
     "TypeError": TypeError,
@@ -99,7 +103,6 @@ _KNOWN_EXCEPTIONS: dict[str, type[Exception]] = {
     "TimeoutError": TimeoutError,
     "ThreadNotFoundError": ThreadNotFoundError,
     "DistributedError": DistributedError,
-    "ConnectionClosedError": ConnectionClosedError,
 }
 
 
@@ -409,21 +412,22 @@ def _error_frame(call_id: str, exc: BaseException) -> ErrorFrame:
     return ErrorFrame(id=call_id, type=type(exc).__name__, message=str(exc), error_kind=classify(exc))
 
 
-def _rehydrate_error(err_type: str, message: str, error_kind: ErrorKind | None = None) -> Exception:
+def _rehydrate_error(err_type: str, message: str, error_kind: str | None = None) -> Exception:
     """Reconstruct a typed exception from a wire ErrorFrame.
 
     Args:
         err_type: The frame's ``type`` — the peer's exception class name.
         message: The frame's ``message``.
-        error_kind: The frame's ``error_kind``; ``None`` from a peer that sends
-            none, which the resulting ``RemoteError`` reads as ``"internal"``.
+        error_kind: The frame's ``error_kind``. ``None`` and kinds outside this
+            build's vocabulary read as ``"internal"`` on the resulting
+            ``RemoteError``.
 
     Returns:
         An instance of the named class when this process knows it and can build
         it from a message, else a :class:`RemoteError` carrying ``error_kind`` so
         the caller can branch on the classification instead of on ``err_type``.
     """
-    kind: ErrorKind = error_kind if error_kind is not None else "internal"
+    kind = coerce_error_kind(error_kind)
     cls = _KNOWN_EXCEPTIONS.get(err_type)
     if cls is None:
         return RemoteError(err_type, message, kind)

--- a/src/ai_functions/network/channel.py
+++ b/src/ai_functions/network/channel.py
@@ -25,12 +25,14 @@ from typing import Any, Self, cast
 
 from pydantic import TypeAdapter
 
-from ..runtime.errors import ThreadNotFoundError
+from ..runtime.errors import DistributedError, ThreadNotFoundError
 from ..types import Event
+from .error_kinds import classify
 from .wire import (
     CallFrame,
     ConnectionClosedError,
     ErrorFrame,
+    ErrorKind,
     EventFrame,
     Frame,
     RemoteError,
@@ -81,13 +83,23 @@ def _describe_transport_close(exc: BaseException) -> tuple[str, bool]:
 
 
 # Map well-known exception classes to / from their type names on the wire.
-# Extend as needed; unknown names produce a RemoteError on the caller side.
+# Every entry must be constructible from a single message string, because that
+# plus the class name is all an ErrorFrame carries. A runtime error whose
+# __init__ takes its own fields (WorkerLostError's worker_id, ConnectionLostError's
+# url and retry count, SerializationError's function name, EventEmissionError's
+# kind/thread/source) cannot be rebuilt from a message without inventing those
+# fields, so it stays out of this table and reaches the caller as a RemoteError
+# whose ``kind`` classifies it. Unknown names produce a RemoteError too.
 _KNOWN_EXCEPTIONS: dict[str, type[Exception]] = {
     "ValueError": ValueError,
+    "TypeError": TypeError,
     "KeyError": KeyError,
     "NotImplementedError": NotImplementedError,
     "RuntimeError": RuntimeError,
+    "TimeoutError": TimeoutError,
     "ThreadNotFoundError": ThreadNotFoundError,
+    "DistributedError": DistributedError,
+    "ConnectionClosedError": ConnectionClosedError,
 }
 
 
@@ -328,10 +340,10 @@ class WireChannel:
                 fut = self._pending.pop(call_id, None)
                 if fut is not None and not fut.done():
                     fut.set_result(value)
-            case ErrorFrame(id=call_id, type=err_type, message=msg):
+            case ErrorFrame(id=call_id, type=err_type, message=msg, error_kind=err_kind):
                 fut = self._pending.pop(call_id, None)
                 if fut is not None and not fut.done():
-                    fut.set_exception(_rehydrate_error(err_type, msg))
+                    fut.set_exception(_rehydrate_error(err_type, msg, err_kind))
             case CallFrame(id=call_id, method=method, params=params):
                 # Dispatch async so multiple inbound calls can interleave.
                 _ = asyncio.create_task(self._handle_call(call_id, method, params))
@@ -353,6 +365,7 @@ class WireChannel:
                 id=call_id,
                 type="NotImplementedError",
                 message=f"no handler registered for method {method!r}",
+                error_kind="invalid_input",
             )
             with suppress(Exception):
                 await self._transport.send(err.model_dump_json())
@@ -361,11 +374,7 @@ class WireChannel:
         try:
             value = await handler(params)
         except Exception as exc:  # noqa: BLE001 -- every handler error becomes a wire frame
-            err = ErrorFrame(
-                id=call_id,
-                type=type(exc).__name__,
-                message=str(exc),
-            )
+            err = _error_frame(call_id, exc)
             with suppress(Exception):
                 await self._transport.send(err.model_dump_json())
             return
@@ -378,15 +387,50 @@ class WireChannel:
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 
-def _rehydrate_error(err_type: str, message: str) -> Exception:
-    """Reconstruct a typed exception from a wire ErrorFrame."""
+def _error_frame(call_id: str, exc: BaseException) -> ErrorFrame:
+    """Encode ``exc`` as the ``ErrorFrame`` answering call ``call_id``.
+
+    A :class:`RemoteError` is relayed rather than re-described: this peer is the
+    middle of a chain (a coordinator answering one client with what another
+    client's worker raised), so the frame keeps the original class name and the
+    classification the far end sent. Re-describing it would report every relayed
+    failure as ``RemoteError`` / ``internal`` and lose the far end's kind at the
+    first hop.
+
+    Args:
+        call_id: Correlation id of the ``CallFrame`` being answered.
+        exc: The exception the handler raised.
+
+    Returns:
+        The frame to send back.
+    """
+    if isinstance(exc, RemoteError):
+        return ErrorFrame(id=call_id, type=exc.remote_type, message=exc.message, error_kind=exc.kind)
+    return ErrorFrame(id=call_id, type=type(exc).__name__, message=str(exc), error_kind=classify(exc))
+
+
+def _rehydrate_error(err_type: str, message: str, error_kind: ErrorKind | None = None) -> Exception:
+    """Reconstruct a typed exception from a wire ErrorFrame.
+
+    Args:
+        err_type: The frame's ``type`` — the peer's exception class name.
+        message: The frame's ``message``.
+        error_kind: The frame's ``error_kind``; ``None`` from a peer that sends
+            none, which the resulting ``RemoteError`` reads as ``"internal"``.
+
+    Returns:
+        An instance of the named class when this process knows it and can build
+        it from a message, else a :class:`RemoteError` carrying ``error_kind`` so
+        the caller can branch on the classification instead of on ``err_type``.
+    """
+    kind: ErrorKind = error_kind if error_kind is not None else "internal"
     cls = _KNOWN_EXCEPTIONS.get(err_type)
     if cls is None:
-        return RemoteError(err_type, message)
+        return RemoteError(err_type, message, kind)
     try:
         return cls(message)
     except Exception:  # noqa: BLE001 -- some exception classes have custom __init__
-        return RemoteError(err_type, message)
+        return RemoteError(err_type, message, kind)
 
 
 EVENT_ADAPTER: TypeAdapter[Event] = TypeAdapter(Event)  # pyright: ignore[reportInvalidTypeForm]

--- a/src/ai_functions/network/error_kinds.py
+++ b/src/ai_functions/network/error_kinds.py
@@ -1,0 +1,97 @@
+"""Exception-to-:data:`~ai_functions.network.wire.ErrorKind` classification registry.
+
+An ``ErrorFrame`` carries the peer's exception class *name*, which is all a
+different process can send. A caller that must decide retry-versus-abort from
+that name ends up matching strings — ``"ThrottlingException"``, a ``"botocore."``
+prefix, ``"ValidationException" in name`` — and every such match breaks when a
+provider renames or wraps an exception. :func:`classify` answers the same
+question from the exception's type, and :func:`register_error_kind` lets the host
+that owns a model provider or storage client declare that provider's exceptions
+once, at the process that raises them, where the real class is in scope.
+
+Registration is process-wide and applies to the whole MRO of the registered
+type, so registering a provider's base exception classifies every subclass.
+
+Usage::
+
+    from botocore.exceptions import ClientError
+    from ai_functions.network import register_error_kind
+
+    register_error_kind(ClientError, "model_unavailable")
+
+This module keeps :mod:`ai_functions.network.wire` free of runtime imports: the
+frame schemas stay transport- and runtime-agnostic while the seed registry here
+names the runtime's own error classes.
+
+Invariants:
+    A. ``classify`` is total — every ``BaseException`` maps to some
+       ``ErrorKind``, defaulting to ``"internal"``, so a caller never has to
+       handle "unclassified".
+    B. The most derived registered ancestor wins, so registering a base class
+       never overrides a more specific registration for a subclass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pydantic import ValidationError
+
+from ..runtime.errors import (
+    ConnectionLostError,
+    EventEmissionError,
+    SerializationError,
+    ThreadIdMismatchError,
+    ThreadNotFoundError,
+    WorkerLostError,
+)
+from .wire import ConnectionClosedError, ErrorKind
+
+_REGISTRY: dict[type[BaseException], ErrorKind] = {
+    asyncio.CancelledError: "cancelled",
+    ThreadNotFoundError: "not_found",
+    WorkerLostError: "worker_lost",
+    ConnectionLostError: "connection_lost",
+    ConnectionClosedError: "connection_lost",
+    # Argument-shaped failures: the same call with the same arguments fails again.
+    ValidationError: "invalid_input",
+    ValueError: "invalid_input",
+    TypeError: "invalid_input",
+    ThreadIdMismatchError: "invalid_input",
+    EventEmissionError: "invalid_input",
+    SerializationError: "invalid_input",
+}
+"""Seeded with the runtime's own errors; hosts extend it via :func:`register_error_kind`."""
+
+
+def classify(exc: BaseException) -> ErrorKind:
+    """Classify ``exc`` by walking its MRO against the registry.
+
+    Args:
+        exc: The exception a peer is about to report, or reported.
+
+    Returns:
+        The kind registered for the most derived class in ``type(exc).__mro__``
+        that has one; ``"internal"`` when none does.
+    """
+    for base in type(exc).__mro__:
+        kind = _REGISTRY.get(base)
+        if kind is not None:
+            return kind
+    return "internal"
+
+
+def register_error_kind(exc_type: type[BaseException], kind: ErrorKind) -> None:
+    """Declare that ``exc_type`` and its subclasses classify as ``kind``.
+
+    Call this once at process start for every third-party exception whose class
+    the wire layer cannot know: a model provider's throttling and access errors
+    (``model_unavailable``), a storage client's missing-key error
+    (``not_found``). The registration replaces any previous one for the same
+    type and shadows registrations for its base classes.
+
+    Args:
+        exc_type: Exception class to classify.
+        kind: The classification a caller should see for it.
+    """
+    _REGISTRY[exc_type] = kind

--- a/src/ai_functions/network/error_kinds.py
+++ b/src/ai_functions/network/error_kinds.py
@@ -1,16 +1,21 @@
-"""Exception-to-:data:`~ai_functions.network.wire.ErrorKind` classification registry.
+"""Exception-to-:data:`~ai_functions.network.wire.ErrorKind` classification.
 
-An ``ErrorFrame`` carries the peer's exception class *name*, which is all a
-different process can send. A caller that must decide retry-versus-abort from
-that name ends up matching strings — ``"ThrottlingException"``, a ``"botocore."``
-prefix, ``"ValidationException" in name`` — and every such match breaks when a
-provider renames or wraps an exception. :func:`classify` answers the same
-question from the exception's type, and :func:`register_error_kind` lets the host
-that owns a model provider or storage client declare that provider's exceptions
-once, at the process that raises them, where the real class is in scope.
+:func:`classify` maps an exception to the :data:`ErrorKind` a peer reads on the
+``ErrorFrame`` that reports it, so callers branch on the kind instead of
+matching the peer's exception class name.
 
-Registration is process-wide and applies to the whole MRO of the registered
-type, so registering a provider's base exception classifies every subclass.
+Two sources feed the classification, checked per class along the MRO:
+
+- An ``error_kind`` class attribute, declared by exception classes this
+  codebase owns (the runtime errors in :mod:`ai_functions.runtime.errors`,
+  :class:`~ai_functions.network.wire.ConnectionClosedError`).
+- A process-wide registry for third-party classes: :func:`register_error_kind`
+  lets the host that owns a model provider or storage client declare that
+  provider's exceptions once. Registration is last-write-wins across the whole
+  process.
+
+Both apply to the whole MRO, so declaring or registering a base exception
+classifies every subclass.
 
 Usage::
 
@@ -19,65 +24,73 @@ Usage::
 
     register_error_kind(ClientError, "model_unavailable")
 
-This module keeps :mod:`ai_functions.network.wire` free of runtime imports: the
-frame schemas stay transport- and runtime-agnostic while the seed registry here
-names the runtime's own error classes.
-
 Invariants:
     A. ``classify`` is total — every ``BaseException`` maps to some
        ``ErrorKind``, defaulting to ``"internal"``, so a caller never has to
        handle "unclassified".
-    B. The most derived registered ancestor wins, so registering a base class
-       never overrides a more specific registration for a subclass.
+    B. The most derived classified ancestor wins, so registering or declaring
+       a base class never overrides a more specific classification for a
+       subclass. At the same MRO level a registration wins over the class's
+       own declaration.
 """
 
 from __future__ import annotations
 
 import asyncio
+from typing import cast, get_args
 
 from pydantic import ValidationError
 
-from ..runtime.errors import (
-    ConnectionLostError,
-    EventEmissionError,
-    SerializationError,
-    ThreadIdMismatchError,
-    ThreadNotFoundError,
-    WorkerLostError,
-)
-from .wire import ConnectionClosedError, ErrorKind
+from .wire import ErrorKind
+
+_VALID_KINDS: frozenset[str] = frozenset(get_args(ErrorKind))
+"""The vocabulary this build of the library knows how to branch on."""
 
 _REGISTRY: dict[type[BaseException], ErrorKind] = {
     asyncio.CancelledError: "cancelled",
-    ThreadNotFoundError: "not_found",
-    WorkerLostError: "worker_lost",
-    ConnectionLostError: "connection_lost",
-    ConnectionClosedError: "connection_lost",
     # Argument-shaped failures: the same call with the same arguments fails again.
     ValidationError: "invalid_input",
     ValueError: "invalid_input",
     TypeError: "invalid_input",
-    ThreadIdMismatchError: "invalid_input",
-    EventEmissionError: "invalid_input",
-    SerializationError: "invalid_input",
 }
-"""Seeded with the runtime's own errors; hosts extend it via :func:`register_error_kind`."""
+"""Seeded with stdlib/pydantic classes; hosts extend it via
+:func:`register_error_kind`. Classes this codebase owns declare their own
+``error_kind`` attribute instead."""
+
+
+def coerce_error_kind(value: str | None) -> ErrorKind:
+    """Read a wire ``error_kind`` value into this build's vocabulary.
+
+    Args:
+        value: The frame's ``error_kind``; ``None`` from a peer that sends none.
+
+    Returns:
+        ``value`` when it is one of this build's :data:`ErrorKind` values,
+        ``"internal"`` otherwise.
+    """
+    if value in _VALID_KINDS:
+        return cast("ErrorKind", value)
+    return "internal"
 
 
 def classify(exc: BaseException) -> ErrorKind:
-    """Classify ``exc`` by walking its MRO against the registry.
+    """Classify ``exc`` by walking its MRO against the registry and declarations.
 
     Args:
         exc: The exception a peer is about to report, or reported.
 
     Returns:
-        The kind registered for the most derived class in ``type(exc).__mro__``
-        that has one; ``"internal"`` when none does.
+        The kind registered or declared (``error_kind`` class attribute) for
+        the most derived class in ``type(exc).__mro__`` that has one;
+        ``"internal"`` when none does.
     """
     for base in type(exc).__mro__:
         kind = _REGISTRY.get(base)
         if kind is not None:
             return kind
+        declared = vars(base).get("error_kind")
+        if isinstance(declared, str) and declared in _VALID_KINDS:
+            return cast("ErrorKind", declared)
     return "internal"
 
 
@@ -87,8 +100,9 @@ def register_error_kind(exc_type: type[BaseException], kind: ErrorKind) -> None:
     Call this once at process start for every third-party exception whose class
     the wire layer cannot know: a model provider's throttling and access errors
     (``model_unavailable``), a storage client's missing-key error
-    (``not_found``). The registration replaces any previous one for the same
-    type and shadows registrations for its base classes.
+    (``not_found``). The registry is process-wide: the registration replaces any
+    previous one for the same type — last write wins — and shadows
+    registrations or declarations on its base classes.
 
     Args:
         exc_type: Exception class to classify.

--- a/src/ai_functions/network/wire.py
+++ b/src/ai_functions/network/wire.py
@@ -10,7 +10,9 @@ Frames are discriminated on ``kind``:
 - ``call``  — request: method name + JSON params. Awaits a ``result``
   or ``error`` frame with matching ``id``.
 - ``result`` — success response; carries a JSON value.
-- ``error``  — failure response; carries an error type + message.
+- ``error``  — failure response; carries an error type, a message and an
+  :data:`ErrorKind` classification the caller can branch on without
+  matching the peer's exception class name.
 - ``event``  — server-initiated event broadcast; no response expected.
 
 A single ``Binary`` field is used for cloudpickle payloads (Spawnables,
@@ -57,6 +59,37 @@ Binary = Annotated[
     PlainSerializer(_encode_binary, return_type=str, when_used="json"),
 ]
 """Binary field encoded as base64 in JSON; accepts raw bytes on construction."""
+
+
+# ── Error classification ─────────────────────────────────────────────────────
+
+ErrorKind = Literal[
+    "cancelled",
+    "not_found",
+    "terminated",
+    "invalid_input",
+    "model_unavailable",
+    "worker_lost",
+    "connection_lost",
+    "internal",
+]
+"""Transport-independent class of a remote failure, carried on every ``ErrorFrame``.
+
+A caller decides retry, escalate or abort from this value, so a peer's exception
+class name never has to be string-matched. The names an
+:class:`ai_functions.network.error_kinds` registry maps to each kind are the
+host's to extend; the vocabulary itself is closed:
+
+- ``cancelled`` — the remote work was cancelled cooperatively.
+- ``not_found`` — the named thread, worker or record does not exist there.
+- ``terminated`` — the thread existed and is gone; retrying the same id cannot work.
+- ``invalid_input`` — the call's arguments are wrong; retrying them cannot work.
+- ``model_unavailable`` — a model provider refused or throttled the call; retry later.
+- ``worker_lost`` — the worker hosting the thread died.
+- ``connection_lost`` — the transport dropped; the call's outcome is unknown.
+- ``internal`` — anything unclassified, which is the default a peer that sends no
+  ``kind`` at all is read as.
+"""
 
 
 # ── Frames ────────────────────────────────────────────────────────────────────
@@ -108,12 +141,16 @@ class ErrorFrame(BaseModel):
             typed exception when possible; otherwise surfaced as
             :class:`RemoteError`.
         message: Human-readable error description.
+        error_kind: Classification of the failure (see :data:`ErrorKind`).
+            Defaults to ``None``, which a reader treats as ``"internal"``, so a
+            peer that sends no classification still produces a valid frame.
     """
 
     kind: Literal["error"] = "error"
     id: str
     type: str
     message: str
+    error_kind: ErrorKind | None = None
 
 
 class EventFrame(BaseModel):
@@ -189,22 +226,31 @@ class WireError(Exception):
 class RemoteError(WireError):
     """A peer returned an ``ErrorFrame`` whose ``type`` we cannot rehydrate.
 
+    ``kind`` is what a caller branches on: the local process has no class for
+    ``remote_type``, so classifying the failure by name is the only alternative
+    and it breaks the moment the peer renames or wraps an exception.
+
     Attributes:
         remote_type (str): The ``type`` field from the ErrorFrame — the
             peer's exception class name.
         message (str): The ``message`` field from the ErrorFrame.
+        kind (ErrorKind): Classification of the failure; ``"internal"`` for a
+            peer that sent no ``error_kind``.
 
     Args:
         remote_type: The ``type`` field from the ErrorFrame.
         message: The ``message`` field from the ErrorFrame.
+        kind: The frame's ``error_kind``, or ``"internal"`` when it carried none.
     """
 
     remote_type: str
     message: str
+    kind: ErrorKind
 
-    def __init__(self, remote_type: str, message: str) -> None:
+    def __init__(self, remote_type: str, message: str, kind: ErrorKind = "internal") -> None:
         self.remote_type = remote_type
         self.message = message
+        self.kind = kind
         super().__init__(f"{remote_type}: {message}")
 
 

--- a/src/ai_functions/network/wire.py
+++ b/src/ai_functions/network/wire.py
@@ -30,7 +30,7 @@ via a thin adapter.
 from __future__ import annotations
 
 import base64
-from typing import Annotated, Any, Literal, Protocol, runtime_checkable
+from typing import Annotated, Any, ClassVar, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer
 
@@ -78,7 +78,10 @@ ErrorKind = Literal[
 A caller decides retry, escalate or abort from this value, so a peer's exception
 class name never has to be string-matched. The names an
 :class:`ai_functions.network.error_kinds` registry maps to each kind are the
-host's to extend; the vocabulary itself is closed:
+host's to extend. On the wire the field is an open string; a kind outside this
+vocabulary is read as ``"internal"``
+(:func:`~ai_functions.network.error_kinds.coerce_error_kind`). The values a
+reader can branch on:
 
 - ``cancelled`` — the remote work was cancelled cooperatively.
 - ``not_found`` — the named thread, worker or record does not exist there.
@@ -142,15 +145,15 @@ class ErrorFrame(BaseModel):
             :class:`RemoteError`.
         message: Human-readable error description.
         error_kind: Classification of the failure (see :data:`ErrorKind`).
-            Defaults to ``None``, which a reader treats as ``"internal"``, so a
-            peer that sends no classification still produces a valid frame.
+            ``None`` and values outside this build's :data:`ErrorKind`
+            vocabulary are read as ``"internal"``.
     """
 
     kind: Literal["error"] = "error"
     id: str
     type: str
     message: str
-    error_kind: ErrorKind | None = None
+    error_kind: str | None = None
 
 
 class EventFrame(BaseModel):
@@ -255,4 +258,11 @@ class RemoteError(WireError):
 
 
 class ConnectionClosedError(WireError):
-    """The peer connection closed before a pending call resolved."""
+    """This process's own connection closed before a pending call resolved.
+
+    Never rehydrated from a peer's ``ErrorFrame``: a peer's
+    ``ConnectionClosedError`` arrives as a :class:`RemoteError` with
+    ``kind == "connection_lost"``.
+    """
+
+    error_kind: ClassVar[ErrorKind] = "connection_lost"

--- a/src/ai_functions/runtime/errors.py
+++ b/src/ai_functions/runtime/errors.py
@@ -1,8 +1,16 @@
-"""Errors specific to runtime execution: dispatcher and distributed transport."""
+"""Errors specific to runtime execution: dispatcher and distributed transport.
+
+Each error declares an ``error_kind`` class attribute — the
+:data:`~ai_functions.network.wire.ErrorKind` value a peer reads when the error
+crosses the wire (see :func:`ai_functions.network.error_kinds.classify`).
+"""
+
+# ``error_kind`` is typed ``str`` rather than ``ErrorKind`` so this module does
+# not import the network layer.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import ClassVar, Literal
 
 from ..types import EventKind, ThreadId, WorkerId
 
@@ -24,6 +32,8 @@ class ThreadIdMismatchError(ValueError):
         Events stored via a ``Coordinator`` always carry a ``thread_id``
         that matches the thread whose log they live in.
     """
+
+    error_kind: ClassVar[str] = "invalid_input"
 
     def __init__(self, event_thread_id: ThreadId, routing_thread_id: ThreadId) -> None:
         self.event_thread_id: ThreadId = event_thread_id
@@ -59,6 +69,8 @@ class EventEmissionError(RuntimeError):
         I5, I7.
     """
 
+    error_kind: ClassVar[str] = "invalid_input"
+
     def __init__(
         self,
         kind: EventKind,
@@ -93,6 +105,8 @@ class ThreadNotFoundError(KeyError):
         thread_id: The id that was not found.
     """
 
+    error_kind: ClassVar[str] = "not_found"
+
     def __init__(self, thread_id: ThreadId) -> None:
         self.thread_id: ThreadId = thread_id
         super().__init__(thread_id)
@@ -110,6 +124,8 @@ class WorkerLostError(DistributedError):
         thread_ids: Ids of threads previously hosted on this worker.
     """
 
+    error_kind: ClassVar[str] = "worker_lost"
+
     def __init__(self, worker_id: WorkerId, thread_ids: list[ThreadId]) -> None:
         self.worker_id: WorkerId = worker_id
         self.thread_ids: list[ThreadId] = thread_ids
@@ -124,6 +140,8 @@ class SerializationError(DistributedError):
         reason: Cloudpickle error text.
     """
 
+    error_kind: ClassVar[str] = "invalid_input"
+
     def __init__(self, function_name: str, reason: str) -> None:
         self.function_name: str = function_name
         super().__init__(f"Cannot serialize '{function_name}': {reason}")
@@ -136,6 +154,8 @@ class ConnectionLostError(DistributedError):
         url: WebSocket URL that could not be reached.
         retries: Number of failed reconnection attempts.
     """
+
+    error_kind: ClassVar[str] = "connection_lost"
 
     def __init__(self, url: str, retries: int) -> None:
         self.url: str = url

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -102,3 +102,6 @@ ai_functions.experimental.economics.function.EconomicThread.__type_params__
 # AIThread._build_agent. It is a diagnostics helper below the public surface
 # (exported nowhere, no external consumers), so the spec does not stub it.
 ai_functions.ai_thread.debug
+# ``ErrorKind = Literal["cancelled", "not_found", ...]``: same Literal-alias false positive as
+# runtime.coordinator_tools_core.SendMessageMode.
+ai_functions.network.wire.ErrorKind

--- a/tests/test_remote_error_kinds.py
+++ b/tests/test_remote_error_kinds.py
@@ -1,0 +1,196 @@
+"""Remote failures carry a classification, so no caller matches exception names.
+
+``ErrorFrame.error_kind`` and ``RemoteError.kind`` let a caller decide retry,
+escalate or abort from a closed vocabulary. ``classify`` seeds that vocabulary
+with the runtime's own errors and ``register_error_kind`` lets a host add the
+model-provider and storage exceptions the wire layer cannot know about.
+
+The field is defaulted on the frame, so a peer that sends no classification
+still produces a valid frame and reads as ``"internal"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from ai_functions.network import (
+    ConnectionClosedError,
+    CoordinatorClient,
+    CoordinatorEndpoint,
+    ErrorFrame,
+    RemoteError,
+    classify,
+    register_error_kind,
+)
+from ai_functions.network.channel import _error_frame, _rehydrate_error  # noqa: PLC2701
+from ai_functions.network.wire import Frame
+from ai_functions.runtime.coordinator import InMemoryCoordinator
+from ai_functions.runtime.errors import (
+    ConnectionLostError,
+    EventEmissionError,
+    SerializationError,
+    ThreadIdMismatchError,
+    ThreadNotFoundError,
+    WorkerLostError,
+)
+from ai_functions.types import EventKind, ThreadId, ThreadInfo, WorkerId
+
+_FRAME_ADAPTER: TypeAdapter[Frame] = TypeAdapter(Frame)  # pyright: ignore[reportInvalidTypeForm]
+_TID = ThreadId("thr-error-kinds")
+
+
+class _ProviderThrottled(Exception):
+    """Stands in for a model provider's throttling exception."""
+
+
+class _ProviderThrottledSubclass(_ProviderThrottled):
+    """A provider exception the host never registered by name."""
+
+
+# ── classify: seeded defaults ─────────────────────────────────────────────
+
+
+def test_unregistered_exception_is_internal() -> None:
+    """``classify`` is total; anything unclassified is ``internal``."""
+    assert classify(Exception("boom")) == "internal"
+
+
+@pytest.mark.parametrize(
+    "exc, expected",
+    [
+        (asyncio.CancelledError(), "cancelled"),
+        (ThreadNotFoundError(_TID), "not_found"),
+        (WorkerLostError(WorkerId("w-1"), [_TID]), "worker_lost"),
+        (ConnectionLostError("ws://host/rpc", 3), "connection_lost"),
+        (ConnectionClosedError("channel closed"), "connection_lost"),
+        (ValueError("bad argument"), "invalid_input"),
+        (TypeError("bad argument"), "invalid_input"),
+        (ThreadIdMismatchError(_TID, ThreadId("thr-other")), "invalid_input"),
+        (EventEmissionError(EventKind.STARTED, _TID, "thread"), "invalid_input"),
+        (SerializationError("my_fn", "not picklable"), "invalid_input"),
+    ],
+)
+def test_runtime_errors_are_seeded(exc: BaseException, expected: str) -> None:
+    """The runtime's own errors classify without any host registration."""
+    assert classify(exc) == expected
+
+
+def test_pydantic_validation_error_is_invalid_input() -> None:
+    """A rejected params model is a caller-input failure, not an internal one."""
+    with pytest.raises(ValidationError) as excinfo:
+        _ = ThreadInfo.model_validate({"thread_id": None})
+    assert classify(excinfo.value) == "invalid_input"
+
+
+# ── register_error_kind: host extension and the MRO walk ──────────────────
+
+
+def test_registration_classifies_a_host_exception() -> None:
+    """A host registers a provider exception instead of matching its name."""
+    register_error_kind(_ProviderThrottled, "model_unavailable")
+    assert classify(_ProviderThrottled("slow down")) == "model_unavailable"
+
+
+def test_registration_reaches_subclasses_through_the_mro() -> None:
+    """Registering a base class classifies every subclass of it."""
+    register_error_kind(_ProviderThrottled, "model_unavailable")
+    assert classify(_ProviderThrottledSubclass("slow down")) == "model_unavailable"
+
+
+def test_most_derived_registration_wins() -> None:
+    """A subclass's own registration is not shadowed by its base's."""
+    register_error_kind(_ProviderThrottled, "model_unavailable")
+    register_error_kind(_ProviderThrottledSubclass, "connection_lost")
+    assert classify(_ProviderThrottledSubclass("dropped")) == "connection_lost"
+    assert classify(_ProviderThrottled("slow down")) == "model_unavailable"
+
+
+# ── ErrorFrame: the field is additive ─────────────────────────────────────
+
+
+def test_error_frame_round_trips_with_kind() -> None:
+    """A classified frame keeps its classification through JSON."""
+    frame = ErrorFrame(id="c-1", type="_ProviderThrottled", message="slow down", error_kind="model_unavailable")
+    decoded = _FRAME_ADAPTER.validate_json(frame.model_dump_json())
+    assert isinstance(decoded, ErrorFrame)
+    assert decoded.error_kind == "model_unavailable"
+
+
+def test_error_frame_from_a_peer_that_sends_no_kind() -> None:
+    """A frame without ``error_kind`` parses; the caller reads it as internal."""
+    decoded = _FRAME_ADAPTER.validate_json('{"kind":"error","id":"c-1","type":"Whatever","message":"boom"}')
+    assert isinstance(decoded, ErrorFrame)
+    assert decoded.error_kind is None
+    rehydrated = _rehydrate_error(decoded.type, decoded.message, decoded.error_kind)
+    assert isinstance(rehydrated, RemoteError)
+    assert rehydrated.kind == "internal"
+
+
+def test_relayed_remote_error_keeps_its_type_and_kind() -> None:
+    """A middle peer re-encodes a ``RemoteError`` without flattening it."""
+    relayed = _error_frame("c-2", RemoteError("_ProviderThrottled", "slow down", "model_unavailable"))
+    assert relayed.type == "_ProviderThrottled"
+    assert relayed.message == "slow down"
+    assert relayed.error_kind == "model_unavailable"
+
+
+def test_known_exception_still_rehydrates_to_its_class() -> None:
+    """A name this process knows becomes that class, not a ``RemoteError``."""
+    rehydrated = _rehydrate_error("ThreadNotFoundError", "thr-1", "not_found")
+    assert isinstance(rehydrated, ThreadNotFoundError)
+
+
+# ── Over a real endpoint ──────────────────────────────────────────────────
+
+
+async def test_remote_error_carries_kind_over_a_real_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown exception type raised on the endpoint arrives classified."""
+    register_error_kind(_ProviderThrottled, "model_unavailable")
+
+    async def _throttle(self: InMemoryCoordinator) -> list[ThreadInfo]:
+        del self
+        raise _ProviderThrottled("slow down")
+
+    monkeypatch.setattr(InMemoryCoordinator, "list_threads", _throttle)
+
+    async with CoordinatorEndpoint() as endpoint:
+        await endpoint.start(host="127.0.0.1", port=0)
+        client = await CoordinatorClient.connect(endpoint.url)
+        async with client:
+            with pytest.raises(RemoteError) as excinfo:
+                _ = await client.list_threads()
+            assert excinfo.value.remote_type == "_ProviderThrottled"
+            assert excinfo.value.kind == "model_unavailable"
+
+
+async def test_missing_thread_over_a_real_endpoint_is_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A seeded runtime error classifies without the host doing anything.
+
+    ``ThreadNotFoundError`` is a name the client knows, so it rehydrates to its
+    own class; the frame that carried it is still classified, which is what a
+    peer that does not know the name reads.
+    """
+    frames: list[ErrorFrame] = []
+    original = _error_frame
+
+    def _capture(call_id: str, exc: BaseException) -> ErrorFrame:
+        frame = original(call_id, exc)
+        frames.append(frame)
+        return frame
+
+    monkeypatch.setattr("ai_functions.network.channel._error_frame", _capture)
+
+    async with CoordinatorEndpoint() as endpoint:
+        await endpoint.start(host="127.0.0.1", port=0)
+        client = await CoordinatorClient.connect(endpoint.url)
+        async with client:
+            with pytest.raises(ThreadNotFoundError):
+                _ = await client.get_thread_info(_TID)
+    assert [f.error_kind for f in frames] == ["not_found"]

--- a/tests/test_remote_error_kinds.py
+++ b/tests/test_remote_error_kinds.py
@@ -12,6 +12,7 @@ still produces a valid frame and reads as ``"internal"``.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
@@ -26,6 +27,7 @@ from ai_functions.network import (
     register_error_kind,
 )
 from ai_functions.network.channel import _error_frame, _rehydrate_error  # noqa: PLC2701
+from ai_functions.network.error_kinds import _REGISTRY, coerce_error_kind  # noqa: PLC2701
 from ai_functions.network.wire import Frame
 from ai_functions.runtime.coordinator import InMemoryCoordinator
 from ai_functions.runtime.errors import (
@@ -42,12 +44,31 @@ _FRAME_ADAPTER: TypeAdapter[Frame] = TypeAdapter(Frame)  # pyright: ignore[repor
 _TID = ThreadId("thr-error-kinds")
 
 
+@pytest.fixture(autouse=True)
+def _pristine_registry() -> Iterator[None]:
+    """Registrations are process-wide; undo this test's before the next one."""
+    saved = dict(_REGISTRY)
+    yield
+    _REGISTRY.clear()
+    _REGISTRY.update(saved)
+
+
 class _ProviderThrottled(Exception):
     """Stands in for a model provider's throttling exception."""
 
 
 class _ProviderThrottledSubclass(_ProviderThrottled):
     """A provider exception the host never registered by name."""
+
+
+class _DeclaresItsKind(Exception):
+    """Stands in for an exception this codebase owns, declaring its own kind."""
+
+    error_kind = "worker_lost"
+
+
+class _InheritsDeclaredKind(_DeclaresItsKind):
+    """A subclass with no declaration of its own."""
 
 
 # ── classify: seeded defaults ─────────────────────────────────────────────
@@ -83,6 +104,18 @@ def test_pydantic_validation_error_is_invalid_input() -> None:
     with pytest.raises(ValidationError) as excinfo:
         _ = ThreadInfo.model_validate({"thread_id": None})
     assert classify(excinfo.value) == "invalid_input"
+
+
+def test_declared_error_kind_classifies_without_registration() -> None:
+    """A class this codebase owns declares ``error_kind`` on itself."""
+    assert classify(_DeclaresItsKind("gone")) == "worker_lost"
+    assert classify(_InheritsDeclaredKind("gone")) == "worker_lost"
+
+
+def test_registration_overrides_a_declaration_on_the_same_class() -> None:
+    """The registry wins over the class's own declaration at the same level."""
+    register_error_kind(_DeclaresItsKind, "model_unavailable")
+    assert classify(_DeclaresItsKind("gone")) == "model_unavailable"
 
 
 # ── register_error_kind: host extension and the MRO walk ──────────────────
@@ -129,6 +162,25 @@ def test_error_frame_from_a_peer_that_sends_no_kind() -> None:
     assert rehydrated.kind == "internal"
 
 
+def test_error_frame_with_a_kind_from_a_newer_vocabulary_still_parses() -> None:
+    """An unknown kind must not reject the frame — that would hang the call."""
+    decoded = _FRAME_ADAPTER.validate_json(
+        '{"kind":"error","id":"c-1","type":"Whatever","message":"boom","error_kind":"brand_new_kind"}'
+    )
+    assert isinstance(decoded, ErrorFrame)
+    assert decoded.error_kind == "brand_new_kind"
+    rehydrated = _rehydrate_error(decoded.type, decoded.message, decoded.error_kind)
+    assert isinstance(rehydrated, RemoteError)
+    assert rehydrated.kind == "internal"
+
+
+def test_coerce_error_kind_passes_known_kinds_through() -> None:
+    """A kind in this build's vocabulary survives coercion unchanged."""
+    assert coerce_error_kind("not_found") == "not_found"
+    assert coerce_error_kind(None) == "internal"
+    assert coerce_error_kind("brand_new_kind") == "internal"
+
+
 def test_relayed_remote_error_keeps_its_type_and_kind() -> None:
     """A middle peer re-encodes a ``RemoteError`` without flattening it."""
     relayed = _error_frame("c-2", RemoteError("_ProviderThrottled", "slow down", "model_unavailable"))
@@ -141,6 +193,14 @@ def test_known_exception_still_rehydrates_to_its_class() -> None:
     """A name this process knows becomes that class, not a ``RemoteError``."""
     rehydrated = _rehydrate_error("ThreadNotFoundError", "thr-1", "not_found")
     assert isinstance(rehydrated, ThreadNotFoundError)
+
+
+def test_remote_connection_closed_error_stays_remote() -> None:
+    """A peer's ``ConnectionClosedError`` arrives as a classified ``RemoteError``, not the local class."""
+    rehydrated = _rehydrate_error("ConnectionClosedError", "channel closed", "connection_lost")
+    assert isinstance(rehydrated, RemoteError)
+    assert not isinstance(rehydrated, ConnectionClosedError)
+    assert rehydrated.kind == "connection_lost"
 
 
 # ── Over a real endpoint ──────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- `src/ai_functions/network/wire.py`: `ErrorFrame` gains `error_kind: ErrorKind | None = None`. `ErrorKind` is a closed `Literal` of eight values: `cancelled`, `not_found`, `terminated`, `invalid_input`, `model_unavailable`, `worker_lost`, `connection_lost`, `internal`. `RemoteError` gains a `kind: ErrorKind` attribute, third positional argument, default `"internal"`.
- `src/ai_functions/network/error_kinds.py` (new): `classify(exc) -> ErrorKind` walks the exception's MRO against a process-wide registry seeded with the runtime's own errors (`ThreadNotFoundError` → `not_found`, `WorkerLostError` → `worker_lost`, `ConnectionLostError` and `ConnectionClosedError` → `connection_lost`, `asyncio.CancelledError` → `cancelled`, `ValueError`/`TypeError`/pydantic `ValidationError`/`ThreadIdMismatchError`/`EventEmissionError`/`SerializationError` → `invalid_input`). `register_error_kind(exc_type, kind)` lets the host that owns a provider or storage client declare its exceptions once, where the class is in scope. The module lives beside `wire.py` so the frame schemas stay free of runtime imports.
- `src/ai_functions/network/channel.py`: a handler exception becomes an `ErrorFrame` through `_error_frame()`, which fills `error_kind` from `classify()`. A `RemoteError` raised by a handler is relayed with its original `remote_type` and `kind` instead of being re-described as `RemoteError`/`internal`, so a coordinator sitting between two clients does not lose the far end's classification at the first hop. `_rehydrate_error()` takes the frame's `error_kind` and puts it on the `RemoteError` it builds. `_KNOWN_EXCEPTIONS` also rehydrates `TypeError`, `TimeoutError`, `DistributedError` and `ConnectionClosedError` by class (each is constructible from a message string).
- `src/ai_functions/network/__init__.py` exports `ErrorKind`, `classify`, `register_error_kind`.
- `spec/ai_functions/network/{__init__,channel,error_kinds,wire}.pyi` mirror the above; `stubtest-allowlist.txt` gains the `ai_functions.network.wire.ErrorKind` Literal-alias entry (same false positive as `runtime.coordinator_tools_core.SendMessageMode`).

## Why

An `ErrorFrame` carries the peer's exception class *name*, which is all another process can send. A caller that has to decide retry-versus-abort from that name ends up matching strings (`"ThrottlingException"`, a `"botocore."` prefix), and every such match breaks when a provider renames or wraps an exception. `error_kind` answers the same question at the peer that raised the exception, where the real class is in scope.

This is the first of the pieces behind #49 (`CoordinatorClient` has no reconnect): a client that redials has to tell `connection_lost` (outcome unknown, safe to resume) from `not_found`/`terminated` (retrying the same id cannot work) without knowing the coordinator's exception hierarchy. The reconnect change itself will follow as its own PR.

## Invariants

- A. `classify` is total: every `BaseException` maps to some `ErrorKind`, defaulting to `internal`, so a caller never handles "unclassified".
- B. The most derived registered ancestor wins: registering a base class never overrides a more specific registration for a subclass.
- C. A relayed `RemoteError` keeps its `remote_type` and `kind` across a hop.
- D. A frame from a peer that sends no `error_kind` still validates and reads as `internal`.

## Compatibility

- `ErrorFrame.error_kind` defaults to `None`; a frame written by an older peer parses unchanged, and an older peer reading a new frame sees one extra field (pydantic ignores it by default).
- `RemoteError(remote_type, message)` still constructs; `kind` is optional with default `"internal"`.
- `_rehydrate_error(err_type, message)` still works with two arguments.
- Exports are additive. No default flips.
- One observable change on the caller side: a peer's `TypeError`, `TimeoutError`, `DistributedError` or `ConnectionClosedError` now rehydrates to that class rather than to `RemoteError`. `except Exception` callers are unaffected; a caller that matched `RemoteError.remote_type == "TypeError"` would need to catch `TypeError` instead.

## Tests

`tests/test_remote_error_kinds.py`, 21 cases:

- Invariant A: `test_unregistered_exception_is_internal`, `test_runtime_errors_are_seeded` (parametrized over the seeded runtime errors), `test_pydantic_validation_error_is_invalid_input`.
- Registration and B: `test_registration_classifies_a_host_exception`, `test_registration_reaches_subclasses_through_the_mro`, `test_most_derived_registration_wins`.
- Frame and D: `test_error_frame_round_trips_with_kind`, `test_error_frame_from_a_peer_that_sends_no_kind`, `test_known_exception_still_rehydrates_to_its_class`.
- C: `test_relayed_remote_error_keeps_its_type_and_kind`.
- End to end over a real `CoordinatorEndpoint` + `CoordinatorClient` on a websocket: `test_remote_error_carries_kind_over_a_real_endpoint`, `test_missing_thread_over_a_real_endpoint_is_not_found`.

## Gate

On `6819869e` (this branch) in a fresh hatch env with mcp 1.30.0, Python 3.12:

```
hatch run ruff format --check src tests   -> 3 files would be reformatted (economics/function.py, memory/base.py, tests/test_economics.py; all three already fail on main), 105 already formatted
hatch run lint                            -> All checks passed!
hatch run check-spec                      -> Success: no issues found in 80 modules
hatch run test -- -q -p no:cacheprovider  -> 474 passed, 2 skipped
```

Note: with the default resolution of `mcp>=1.29` a fresh env gets mcp 2.1.1 and `tests/test_codex_agent.py` / `tests/test_tool_server.py` fail at import on `main` and on this branch alike; #47 fixes that. The gate above was run with `mcp<2` pinned in the env to keep the comparison to `main` clean.
