### PR TITLE
fix(types.events): CustomEvent extends BaseEvent so custom-event routing survives the wire

### DIFF
--- a/spec/ai_functions/network/client.pyi
+++ b/spec/ai_functions/network/client.pyi
@@ -29,6 +29,9 @@ from ..protocols import Coordinator, OnEventCallback, Spawnable, Subscription
 from ..types import Event, EventId, EventKind, MessageId, ThreadId, ThreadInfo, ThreadStatus, WorkerId
 from .wire import Transport
 
+APPEND_ERROR_HISTORY: int
+"""How many ``append_event`` failures :attr:`CoordinatorClient.append_errors` keeps."""
+
 
 @final
 class CoordinatorClient(Coordinator):
@@ -370,8 +373,24 @@ class CoordinatorClient(Coordinator):
         later via :meth:`on`. Per I11, a failure of the scheduled RPC is logged
         and swallowed rather than propagated to the (often sync) caller.
 
+        A rejected append is observable: the failure is logged at ERROR and
+        recorded on :attr:`append_errors`, so a caller that must know whether
+        the endpoint took the event can read that instead of watching the log.
+
         Args:
             event: The event to append; ``event.thread_id`` must be set.
+        """
+        ...
+
+    @property
+    def append_errors(self) -> tuple[BaseException, ...]:
+        """Failures raised by the fire-and-forget :meth:`append_event` RPCs.
+
+        Oldest first, capped at :data:`APPEND_ERROR_HISTORY` entries so a peer
+        that rejects every append cannot grow the client without bound. Empty
+        while every scheduled append has been accepted, which is what makes a
+        remote rejection (an unrouted event, a closed channel) observable to a
+        caller of the synchronous, fire-and-forget :meth:`append_event`.
         """
         ...
 

--- a/spec/ai_functions/types/events.pyi
+++ b/spec/ai_functions/types/events.pyi
@@ -449,18 +449,38 @@ class TraceDelegationEvent(BaseEvent):
 # ── User-defined extension ──
 
 
-class CustomEvent(BaseModel):
+class CustomEvent(BaseEvent):
     """Catch-all event for user-defined ``kind`` values.
 
-    A ``mode="before"`` validator reshapes flat input dicts: all keys
-    other than declared model fields land inside ``payload``. A
-    ``model_serializer`` flattens on the way out, so the wire format
-    round-trips through pydantic.
+    Carries the same routing fields as every other event (``id``,
+    ``timestamp``, ``thread_id``, ``thread_name``, ``message_id``), so routing
+    survives the wire: a subscription filtered by ``thread_id`` matches a
+    custom event that arrived over a ``CoordinatorClient``, ``get_events``
+    returns it under its own thread, and ``Coordinator.append_event`` accepts
+    it from a client that stamped the id itself.
+
+    A ``mode="before"`` validator reshapes flat input dicts: all keys other
+    than declared model fields land inside ``payload``. A ``model_serializer``
+    flattens on the way out, emitting the declared fields next to the
+    payload's entries, so the wire format round-trips through pydantic.
+
+    A top-level key that names a declared field binds to that field, so
+    ``CustomEvent(kind="k", thread_id=tid)`` routes rather than filling
+    ``payload``. An entry inside an explicit ``payload`` keeps its place: the
+    serializer re-nests payload entries whose keys shadow a declared field
+    under a ``"payload"`` key, which stops a payload entry named ``id`` or
+    ``thread_id`` from overwriting the event's own routing on a round trip.
+
+    ``BaseEvent`` is frozen, so an instance is immutable; build a routed copy
+    with ``model_copy(update={"thread_id": ...})``.
 
     If ``payload`` is provided explicitly, any extra top-level keys are
     merged into it (extras take precedence over explicit-payload entries
     that have the same key). Known declared fields on subclasses (if any)
     are preserved as-is and not swept into ``payload``.
+
+    Invariants:
+        I2.
     """
 
     kind: str
@@ -479,14 +499,21 @@ SystemEvent = Annotated[
     Field(discriminator="kind")
 ]
 
-Event = SystemEvent | CustomEvent
+Event = Annotated[SystemEvent | CustomEvent, Field(union_mode="left_to_right")]
 """Tagged union of every built-in event variant plus the ``CustomEvent`` fallback.
 
-Pydantic tries union members left-to-right (with the discriminated union
-as a single fast-path attempt first). If ``kind`` does not match any
-``SystemEvent``, it falls through to ``CustomEvent``, whose
+Pydantic tries union members left-to-right: the discriminated ``SystemEvent``
+union is a single fast-path attempt on ``kind``, and only a kind that matches
+no built-in variant falls through to ``CustomEvent``, whose
 ``model_validator(mode="before")`` reshapes the raw dict into
-``{kind, payload}``.
+``{kind, routing fields, payload}`` — every key outside ``CustomEvent``'s
+declared fields lands in ``payload``, so an unknown kind never loses data
+and never loses its routing.
+
+``union_mode="left_to_right"`` is what keeps a built-in kind out of
+``CustomEvent``: smart mode tie-breaks two matching members by the number of
+fields set, and ``CustomEvent`` declares every routing field, so it would
+outscore the concrete variant a built-in kind belongs to and swallow it.
 
 Users can write their own union to add correct parsing of their own
 event types.

--- a/src/ai_functions/ai_thread/summarization.py
+++ b/src/ai_functions/ai_thread/summarization.py
@@ -340,8 +340,8 @@ class DefaultSummarizationStrategy:
             raise SummarizationFailedError(
                 function_name="",
                 reason=(
-                    "summarization prefix ends on a CustomEvent without an "
-                    "id field; cannot use it as an until_event_id marker"
+                    "summarization prefix ends on an event without an id "
+                    "field; cannot use it as an until_event_id marker"
                 ),
             )
 

--- a/src/ai_functions/cli/commands.py
+++ b/src/ai_functions/cli/commands.py
@@ -290,8 +290,8 @@ def _latest_event_id(events: list[Event]) -> EventId | None:
     """Return the id of the newest event, or ``None`` if there is none.
 
     ``get_events`` is oldest-first, so the last event with an ``id``
-    attribute is the watermark. ``CustomEvent`` is not a ``BaseEvent``
-    and carries no ``id``, so it is skipped.
+    attribute is the watermark. A user-defined ``Event`` union member that
+    declares no ``id`` is skipped.
     """
     for event in reversed(events):
         event_id = getattr(event, "id", None)

--- a/src/ai_functions/network/client.py
+++ b/src/ai_functions/network/client.py
@@ -21,6 +21,8 @@ to the matching ``LocalWorker`` instance via the shared ``WireChannel``.
 from __future__ import annotations
 
 import asyncio
+import logging
+from collections import deque
 from collections.abc import Awaitable, Callable
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Self, cast, final
@@ -105,6 +107,12 @@ class _ClientSubscription(Subscription):
         self.unsubscribe()
 
 
+_logger: logging.Logger = logging.getLogger("ai_functions.network.client")
+
+APPEND_ERROR_HISTORY: int = 32
+"""How many ``append_event`` failures :attr:`CoordinatorClient.append_errors` keeps."""
+
+
 class _Subscriber:
     __slots__ = ("callback", "thread_id", "kinds")
 
@@ -156,11 +164,13 @@ class CoordinatorClient(Coordinator):
         "_channel",
         "_subscribers",
         "_workers",
+        "_append_errors",
     )
 
     _channel: WireChannel
     _subscribers: list[_Subscriber]
     _workers: dict[WorkerId, WorkerAdapter]
+    _append_errors: deque[BaseException]
 
     @classmethod
     async def connect(cls, url: str) -> Self:
@@ -192,6 +202,7 @@ class CoordinatorClient(Coordinator):
         self._channel = WireChannel(transport)
         self._subscribers = []
         self._workers = {}
+        self._append_errors = deque(maxlen=APPEND_ERROR_HISTORY)
         _ = self._channel.on_event(self._dispatch_event)
 
     def _dispatch_event(self, event: Event) -> None:
@@ -608,6 +619,10 @@ class CoordinatorClient(Coordinator):
         later via :meth:`on`. Per I11, a failure of the scheduled RPC is logged
         and swallowed rather than propagated to the (often sync) caller.
 
+        A rejected append is observable: the failure is logged at ERROR and
+        recorded on :attr:`append_errors`, so a caller that must know whether
+        the endpoint took the event can read that instead of watching the log.
+
         Args:
             event: The event to append; ``event.thread_id`` must be set.
         """
@@ -616,15 +631,23 @@ class CoordinatorClient(Coordinator):
         async def _send() -> None:
             try:
                 _ = await self._call("coordinator.append_event", params)
-            except Exception as exc:  # noqa: BLE001 -- log + swallow (I11)
-                import logging
-
-                logging.getLogger("ai_functions.network.client").warning(
-                    "append_event RPC failed: %r",
-                    exc,
-                )
+            except Exception as exc:  # noqa: BLE001 -- record + swallow (I11)
+                self._append_errors.append(exc)
+                _logger.error("append_event RPC failed for kind %r: %r", event.kind, exc)
 
         _ = asyncio.create_task(_send())
+
+    @property
+    def append_errors(self) -> tuple[BaseException, ...]:
+        """Failures raised by the fire-and-forget :meth:`append_event` RPCs.
+
+        Oldest first, capped at :data:`APPEND_ERROR_HISTORY` entries so a peer
+        that rejects every append cannot grow the client without bound. Empty
+        while every scheduled append has been accepted, which is what makes a
+        remote rejection (an unrouted event, a closed channel) observable to a
+        caller of the synchronous, fire-and-forget :meth:`append_event`.
+        """
+        return tuple(self._append_errors)
 
     async def get_events(
         self,

--- a/src/ai_functions/runtime/usage.py
+++ b/src/ai_functions/runtime/usage.py
@@ -42,8 +42,9 @@ async def last_event_id(coordinator: Coordinator, thread_id: ThreadId) -> EventI
     """
     events = await coordinator.get_events(thread_id)
     for event in reversed(events):
-        # CustomEvent carries no id; only BaseEvent-backed events can anchor
-        # a since_id cursor, so skip to the newest event that has one.
+        # A user-defined ``Event`` union member may declare no ``id``; only an
+        # event that has one can anchor a since_id cursor, so skip to the
+        # newest event that does.
         event_id: EventId | None = getattr(event, "id", None)
         if event_id is not None:
             return event_id

--- a/src/ai_functions/runtime/worker.py
+++ b/src/ai_functions/runtime/worker.py
@@ -642,7 +642,7 @@ class LocalWorker(WorkerAdapter):
             raise EventEmissionError(kind=kind, thread_id=thread_id, source=source)
         if source == "runtime" and kind in _BRIDGE_KINDS:
             raise EventEmissionError(kind=kind, thread_id=thread_id, source=source)
-        event_tid = cast("ThreadId | None", getattr(event, "thread_id", None))
+        event_tid = event.thread_id
         if event_tid is None:
             stamped = event.model_copy(update={"thread_id": thread_id})
         elif event_tid != thread_id:

--- a/src/ai_functions/types/events.py
+++ b/src/ai_functions/types/events.py
@@ -471,18 +471,38 @@ class TraceDelegationEvent(BaseEvent):
 # ── User-defined extension ────────────────────────────────────────────────────
 
 
-class CustomEvent(BaseModel):
+class CustomEvent(BaseEvent):
     """Catch-all event for user-defined ``kind`` values.
 
-    A ``mode="before"`` validator reshapes flat input dicts: all keys
-    other than declared model fields land inside ``payload``. A
-    ``model_serializer`` flattens on the way out, so the wire format
-    round-trips through pydantic.
+    Carries the same routing fields as every other event (``id``,
+    ``timestamp``, ``thread_id``, ``thread_name``, ``message_id``), so routing
+    survives the wire: a subscription filtered by ``thread_id`` matches a
+    custom event that arrived over a ``CoordinatorClient``, ``get_events``
+    returns it under its own thread, and ``Coordinator.append_event`` accepts
+    it from a client that stamped the id itself.
+
+    A ``mode="before"`` validator reshapes flat input dicts: all keys other
+    than declared model fields land inside ``payload``. A ``model_serializer``
+    flattens on the way out, emitting the declared fields next to the
+    payload's entries, so the wire format round-trips through pydantic.
+
+    A top-level key that names a declared field binds to that field, so
+    ``CustomEvent(kind="k", thread_id=tid)`` routes rather than filling
+    ``payload``. An entry inside an explicit ``payload`` keeps its place: the
+    serializer re-nests payload entries whose keys shadow a declared field
+    under a ``"payload"`` key, which stops a payload entry named ``id`` or
+    ``thread_id`` from overwriting the event's own routing on a round trip.
+
+    ``BaseEvent`` is frozen, so an instance is immutable; build a routed copy
+    with ``model_copy(update={"thread_id": ...})``.
 
     If ``payload`` is provided explicitly, any extra top-level keys are
     merged into it (extras take precedence over explicit-payload entries
     that have the same key). Known declared fields on subclasses (if any)
     are preserved as-is and not swept into ``payload``.
+
+    Invariants:
+        I2.
     """
 
     kind: str
@@ -520,20 +540,28 @@ class CustomEvent(BaseModel):
 
     @model_serializer(mode="wrap")
     def _flatten_payload(self, handler: Any) -> dict[str, object]:  # pyright: ignore[reportAny, reportExplicitAny]
-        """Emit a flat dict: ``{"kind": ..., **payload}``.
+        """Emit a flat dict: the declared fields plus the payload's entries.
 
         Args:
             handler: Pydantic's default serializer for the model.
 
         Returns:
-            A flat dict where ``payload`` contents appear at the top
-            level alongside ``kind``. ``payload`` itself is never a key
-            in the output, even when empty.
+            A flat dict carrying ``kind``, the routing fields inherited from
+            :class:`BaseEvent`, and every payload entry at the top level.
+            ``payload`` appears as a key only to carry entries whose keys
+            shadow a declared field, which the before-validator reads back
+            into ``payload``; a payload with no such entry never produces the
+            key, even when empty.
         """
         default = cast("dict[str, object]", handler(self))
         payload = default.pop("payload", None)
         if isinstance(payload, dict):
-            default.update(cast("dict[str, object]", payload))
+            declared = set(type(self).model_fields)
+            entries = cast("dict[str, object]", payload)
+            default.update({k: v for k, v in entries.items() if k not in declared})
+            shadowed = {k: v for k, v in entries.items() if k in declared}
+            if shadowed:
+                default["payload"] = shadowed
         return default
 
 
@@ -564,13 +592,19 @@ SystemEvent = Annotated[
     Field(discriminator="kind"),
 ]
 
-Event = SystemEvent | CustomEvent
+Event = Annotated[SystemEvent | CustomEvent, Field(union_mode="left_to_right")]
 """Tagged union of every built-in event variant plus the ``CustomEvent`` fallback.
 
-Pydantic tries union members left-to-right (with the discriminated union as a single
-fast-path attempt first). If kind doesn't match any SystemEvent, it falls through to
-CustomEvent, whose model_validator(mode="before") reshapes the raw dict into
-{kind, payload}.
+Pydantic tries union members left-to-right: the discriminated SystemEvent union is a
+single fast-path attempt on ``kind``, and only a kind that matches no built-in variant
+falls through to CustomEvent, whose model_validator(mode="before") reshapes the raw dict
+into {kind, routing fields, payload} — every key outside CustomEvent's declared fields
+lands in payload, so an unknown kind never loses data and never loses its routing.
+
+``union_mode="left_to_right"`` is what keeps a built-in kind out of CustomEvent: smart
+mode tie-breaks two matching members by the number of fields set, and CustomEvent
+declares every routing field, so it would outscore the concrete variant a built-in kind
+belongs to and swallow it.
 
 Users can write their own union like the above to add correct parsing of their own
 event types.

--- a/stubtest-allowlist.txt
+++ b/stubtest-allowlist.txt
@@ -28,6 +28,9 @@ ai_functions.network.wire.Binary
 ai_functions.network.wire.Binary.*
 ai_functions.network.wire.Frame
 ai_functions.types.events.SystemEvent
+# ``Event = Annotated[SystemEvent | CustomEvent, Field(union_mode="left_to_right")]``: same
+# _AnnotatedAlias false positive as types.events.SystemEvent.
+ai_functions.types.events.Event
 ai_functions.types.policy.Policy
 ai_functions.memory.frozen.Frozen
 ai_functions.memory.procedural.Procedural

--- a/tests/test_events_custom_wire.py
+++ b/tests/test_events_custom_wire.py
@@ -1,0 +1,163 @@
+"""``CustomEvent`` routing survives serialization and a real WebSocket hop.
+
+A custom event declares the routing fields every other event declares, so the
+three places routing is read all agree on it: ``EVENT_ADAPTER`` keeps
+``thread_id`` in the wire dict, a filtered subscription over a
+``CoordinatorClient`` matches it, and ``get_events(thread_id)`` returns it under
+that thread. A client-side ``append_event`` of a routed custom event is accepted
+by the remote coordinator; an unrouted one is rejected and the rejection shows
+up on ``client.append_errors``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+from ai_functions.network import CoordinatorClient, CoordinatorEndpoint
+from ai_functions.network.channel import EVENT_ADAPTER
+from ai_functions.testing import RuntimeHarness
+from ai_functions.types import CustomEvent, Event, ThreadId
+from ai_functions.types.ids import MessageId
+
+_TID = ThreadId("thr-custom-wire")
+
+
+class _Annotated(CustomEvent):
+    """A user subclass that declares its own field next to the routing ones."""
+
+    step: str = ""
+
+
+async def _until(predicate: Callable[[], bool], *, timeout: float = 2.0) -> None:
+    """Poll ``predicate`` until true, or fail the test after ``timeout``."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not reached within timeout")
+
+
+# ── a: the adapter keeps routing on a stamped custom event ────────────────
+
+
+def test_a1_dump_includes_thread_id() -> None:
+    """The wire dict for a stamped custom event carries ``thread_id``."""
+    stamped = CustomEvent(kind="my_kind", payload={"a": 1}).model_copy(update={"thread_id": _TID})
+    dumped = EVENT_ADAPTER.dump_python(stamped)
+    assert dumped["thread_id"] == _TID
+
+
+def test_a2_round_trip_preserves_routing() -> None:
+    """Every routing field survives dump → validate through the union adapter."""
+    original = CustomEvent(
+        kind="my_kind",
+        thread_id=_TID,
+        thread_name="worker-a",
+        message_id=MessageId("msg-1"),
+        payload={"a": 1},
+    )
+    reparsed = EVENT_ADAPTER.validate_python(EVENT_ADAPTER.dump_python(original))
+    assert isinstance(reparsed, CustomEvent)
+    assert reparsed.thread_id == _TID
+    assert reparsed.thread_name == "worker-a"
+    assert reparsed.message_id == MessageId("msg-1")
+    assert reparsed.id == original.id
+    assert reparsed.payload == {"a": 1}
+
+
+def test_a3_subclass_declared_fields_round_trip() -> None:
+    """A subclass's own field stays declared; routing rides alongside it."""
+    original = _Annotated(kind="my_kind", thread_id=_TID, step="validate", payload={"a": 1})
+    dumped = _Annotated.model_validate(original.model_dump())
+    assert dumped.step == "validate"
+    assert dumped.thread_id == _TID
+    assert dumped.payload == {"a": 1}
+    # Through the ``Event`` union the subclass degrades to ``CustomEvent``;
+    # ``step`` is an undeclared key there, so it lands in the payload.
+    via_union = EVENT_ADAPTER.validate_python(original.model_dump())
+    assert isinstance(via_union, CustomEvent)
+    assert via_union.thread_id == _TID
+    assert via_union.payload == {"a": 1, "step": "validate"}
+
+
+# ── b: the runtime gate stamps the declared field ─────────────────────────
+
+
+async def test_b1_route_event_stamps_custom_event() -> None:
+    """An unrouted custom event leaves the runtime gate carrying the thread id."""
+    async with RuntimeHarness() as h:
+        h.worker._route_event(  # noqa: SLF001 -- the gate is the unit under test
+            CustomEvent(kind="my_kind", payload={"a": 1}),
+            thread_id=_TID,
+            source="thread",
+        )
+        stored = await h.coordinator.get_events(_TID)
+        assert [e.thread_id for e in stored] == [_TID]
+
+
+# ── c: a real endpoint + client agree on the routing ─────────────────────
+
+
+async def test_c1_filtered_subscription_receives_custom_event() -> None:
+    """``client.on(cb, thread_id=...)`` fires for a custom event from the endpoint."""
+    async with CoordinatorEndpoint() as endpoint:
+        await endpoint.start(host="127.0.0.1", port=0)
+        client = await CoordinatorClient.connect(endpoint.url)
+        async with client:
+            received: list[Event] = []
+            with client.on(received.append, thread_id=_TID):
+                endpoint.coordinator.append_event(
+                    CustomEvent(kind="my_kind", thread_id=_TID, payload={"a": 1}),
+                )
+                await _until(lambda: bool(received))
+            event = received[0]
+            assert isinstance(event, CustomEvent)
+            assert event.thread_id == _TID
+            assert event.payload == {"a": 1}
+
+
+async def test_c2_get_events_returns_routed_custom_event() -> None:
+    """``client.get_events(thread_id)`` returns the custom event with its routing."""
+    async with CoordinatorEndpoint() as endpoint:
+        await endpoint.start(host="127.0.0.1", port=0)
+        client = await CoordinatorClient.connect(endpoint.url)
+        async with client:
+            endpoint.coordinator.append_event(
+                CustomEvent(kind="my_kind", thread_id=_TID, payload={"a": 1}),
+            )
+            replayed = await client.get_events(_TID)
+            assert [e.thread_id for e in replayed] == [_TID]
+            assert [e.kind for e in replayed] == ["my_kind"]
+
+
+async def test_c3_client_append_event_lands_on_the_endpoint() -> None:
+    """A routed custom event appended from the client reaches the server log."""
+    async with CoordinatorEndpoint() as endpoint:
+        await endpoint.start(host="127.0.0.1", port=0)
+        client = await CoordinatorClient.connect(endpoint.url)
+        async with client:
+            client.append_event(CustomEvent(kind="from_client", thread_id=_TID, payload={"a": 1}))
+            await _until(lambda: bool(endpoint.coordinator._events.get(_TID)))  # noqa: SLF001
+            stored = await endpoint.coordinator.get_events(_TID)
+            assert [(e.kind, e.thread_id) for e in stored] == [("from_client", _TID)]
+            assert client.append_errors == ()
+
+
+async def test_c4_unrouted_append_is_recorded_on_append_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A rejected append is observable without watching the log by hand."""
+    async with CoordinatorEndpoint() as endpoint:
+        await endpoint.start(host="127.0.0.1", port=0)
+        client = await CoordinatorClient.connect(endpoint.url)
+        async with client:
+            with caplog.at_level("ERROR", logger="ai_functions.network.client"):
+                client.append_event(CustomEvent(kind="unrouted", payload={"a": 1}))
+                await _until(lambda: bool(client.append_errors))
+            assert "thread_id" in str(client.append_errors[0])
+            assert "append_event RPC failed" in caplog.text
+            assert await endpoint.coordinator.get_events(_TID) == []

--- a/tests/test_pure_functions.py
+++ b/tests/test_pure_functions.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, TypeAdapter
 from ai_functions import ai_function
 from ai_functions.testing import RuntimeHarness, ScriptedModel, Turn
 from ai_functions.types import Event, ThreadId
-from ai_functions.types.events import CustomEvent, MessageUserEvent
+from ai_functions.types.events import CustomEvent, MessageUserEvent, StartedEvent
 
 # ── serialize_result / deserialize_result round-trip ──────────────────────
 
@@ -109,6 +109,20 @@ def test_known_kind_does_not_hit_custom_event() -> None:
     assert parsed.text == "hi"
 
 
+def test_fieldless_system_event_round_trips_to_its_own_class() -> None:
+    """A built-in kind whose variant declares no extra field is not swallowed.
+
+    ``StartedEvent`` sets exactly the routing fields ``CustomEvent`` also
+    declares, so a union that scores members by fields-set would hand its dict
+    to ``CustomEvent``; the union is left-to-right precisely to prevent that.
+    """
+    ta: TypeAdapter[Event] = TypeAdapter(Event)
+    original = StartedEvent(thread_id=ThreadId("thr-1"), thread_name="agent")
+    reparsed = ta.validate_json(ta.dump_json(original))
+    assert isinstance(reparsed, StartedEvent)
+    assert reparsed == original
+
+
 def test_custom_event_collects_extra_fields_into_payload() -> None:
     """Extra top-level fields are folded into ``payload`` by the before-validator."""
     ta: TypeAdapter[Event] = TypeAdapter(Event)
@@ -118,19 +132,63 @@ def test_custom_event_collects_extra_fields_into_payload() -> None:
 
 
 def test_custom_event_serializes_flat() -> None:
-    """``model_dump`` emits ``{"kind": ..., **payload}`` — no ``"payload"`` key."""
-    dumped = CustomEvent(kind="my_kind", payload={"a": "hello", "b": 1}).model_dump()
-    assert dumped == {"kind": "my_kind", "a": "hello", "b": 1}
+    """``model_dump`` emits the declared fields plus the payload, flat."""
+    event = CustomEvent(kind="my_kind", thread_id=ThreadId("thr-1"), payload={"a": "hello", "b": 1})
+    dumped = event.model_dump()
+    assert dumped == {
+        "id": event.id,
+        "timestamp": event.timestamp,
+        "thread_id": "thr-1",
+        "thread_name": None,
+        "message_id": None,
+        "kind": "my_kind",
+        "a": "hello",
+        "b": 1,
+    }
     assert "payload" not in dumped
 
 
 def test_custom_event_flat_wire_format_round_trips() -> None:
-    """Flat wire dict → validator → serializer reproduces the same flat dict."""
+    """Flat wire dict → validator → serializer keeps every key it was given."""
     ta: TypeAdapter[Event] = TypeAdapter(Event)
-    flat = {"kind": "my_kind", "a": "hello", "b": 1}
+    flat = {"kind": "my_kind", "thread_id": "thr-1", "a": "hello", "b": 1}
     parsed = ta.validate_python(flat)
     dumped = ta.dump_python(parsed)
-    assert dumped == flat
+    assert {k: dumped[k] for k in flat} == flat
+    assert ta.validate_python(dumped) == parsed
+
+
+def test_custom_event_routing_fields_are_declared_not_payload() -> None:
+    """A routing key stays out of ``payload`` and survives serialization."""
+    ta: TypeAdapter[Event] = TypeAdapter(Event)
+    event = CustomEvent(kind="my_kind", thread_id=ThreadId("thr-7"), payload={"a": 1})
+    assert event.thread_id == ThreadId("thr-7")
+    assert event.payload == {"a": 1}
+    dumped = ta.dump_python(event)
+    assert dumped["thread_id"] == "thr-7"
+    assert ta.validate_python(dumped).thread_id == ThreadId("thr-7")
+
+
+def test_custom_event_shadowing_payload_key_round_trips() -> None:
+    """A payload entry named like a declared field never eats the routing field."""
+    ta: TypeAdapter[Event] = TypeAdapter(Event)
+    event = CustomEvent(kind="my_kind", thread_id=ThreadId("thr-7"), payload={"id": "0", "text": "t"})
+    dumped = ta.dump_python(event)
+    # The shadowing entry is re-nested; the top-level ``id`` is the event's own.
+    assert dumped["id"] == event.id
+    assert dumped["payload"] == {"id": "0"}
+    assert dumped["text"] == "t"
+    reparsed = ta.validate_python(dumped)
+    assert reparsed == event
+    assert reparsed.payload == {"id": "0", "text": "t"}
+
+
+def test_custom_event_is_frozen() -> None:
+    """``CustomEvent`` is immutable like every other event; copies re-route it."""
+    event = CustomEvent(kind="my_kind")
+    with pytest.raises(Exception):  # noqa: B017, PT011 -- pydantic raises ValidationError
+        event.thread_id = ThreadId("thr-injected")  # type: ignore[misc]
+    assert event.model_copy(update={"thread_id": ThreadId("thr-1")}).thread_id == ThreadId("thr-1")
 
 
 def test_custom_event_explicit_payload_still_collects_extras() -> None:

--- a/tests/test_reconstruct_roundtrip.py
+++ b/tests/test_reconstruct_roundtrip.py
@@ -34,7 +34,7 @@ from ai_functions.testing import (
     assert_messages_equivalent,
     normalize_messages,
 )
-from ai_functions.types import EventKind
+from ai_functions.types import CustomEvent, EventKind
 
 
 @ai_function[str](structured_output=False)
@@ -331,3 +331,27 @@ def test_normalizer_is_deep_copy() -> None:
     result = normalize_messages(original)  # type: ignore[arg-type]
     result[0]["content"].append({"text": "y"})  # type: ignore[arg-type, index]
     assert len(original[0]["content"]) == 1  # type: ignore[arg-type, index]
+
+
+# ── I9: custom events are inert to reconstruction ─────────────────────────
+
+
+async def test_custom_event_in_log_is_inert_to_reconstruction() -> None:
+    """A routed ``CustomEvent`` in the log adds no message (I9).
+
+    A custom event carries the same routing fields as a conversation event,
+    so nothing but its ``kind`` distinguishes it during the match; this pins
+    that ``reconstruct_messages`` still skips it and the history stays equal
+    to the live ``agent.messages``.
+    """
+    async with RuntimeHarness() as h:
+        model = ScriptedModel([Turn(text="hello there")])
+        handle = await h.spawn(_text_only.replace(model=model))
+        await handle.run("hi")
+        h.coordinator.append_event(CustomEvent(kind="my_app_metric", thread_id=handle.id, payload={"step": 1}))
+        events = await h.events(handle.id)
+        assert any(isinstance(e, CustomEvent) for e in events)
+        assert_messages_equivalent(
+            h.agent_messages(handle.id),
+            reconstruct_messages(events),
+        )


### PR DESCRIPTION
## Summary

`CustomEvent` now extends `BaseEvent`, so it declares the same routing fields every other event declares (`id`, `timestamp`, `thread_id`, `thread_name`, `message_id`) and they survive serialization. Before this change `LocalWorker._route_event` stamped `thread_id` onto an attribute the model did not declare, which worked in one process but was dropped by `EVENT_ADAPTER` on the way to the wire. Over a `CoordinatorClient`, every custom event arrived with `thread_id=None`: filtered subscriptions (`coord.on(cb, thread_id=...)`) never fired for custom events, `get_events(thread_id)` returned them unrouted, and a client-side `append_event(CustomEvent(...))` was rejected by the remote coordinator and only logged.

Closes #48.

## What changed

- `types/events.py`: `CustomEvent(BaseEvent)` with `kind` and `payload`; `Event` becomes `Annotated[SystemEvent | CustomEvent, Field(union_mode="left_to_right")]`. The discriminated `SystemEvent` union is tried first and `CustomEvent` is the fallback for unknown kinds only. Smart-mode union resolution would otherwise tie-break by the number of fields set, and a `CustomEvent` that now declares every routing field would outscore a fieldless concrete variant such as `StartedEvent`.
- The serializer emits the declared fields alongside the flattened payload. A payload entry whose key shadows a declared field (`id`, `thread_id`, ...) is re-nested under a `payload` key so it cannot overwrite the event's own routing on a round trip. (`codex_plan` emits a payload entry named `id`.)
- `network/client.py`: `CoordinatorClient.append_event` stays fire-and-forget and records each failure on a new public `append_errors` property (last 32, oldest first) at ERROR level, so a caller can observe a rejected append instead of only finding it in a log.
- `ai_thread/summarization.py`, `cli/commands.py`, `runtime/usage.py`, `runtime/worker.py`: read the now-declared fields directly instead of `getattr` fallbacks.
- `spec/` stubs mirror the new shapes; `stubtest-allowlist.txt` gains the `Event` union entry, mirroring the existing `SystemEvent` one.

## Behavior changes

- A top-level key naming a routing field binds to that field: `CustomEvent(kind=..., thread_id=x)` routes rather than filling `payload`.
- `CustomEvent` inherits `BaseEvent`'s frozen config. A caller that mutated an instance in place must use `model_copy(update=...)`.

## Wire compatibility

- An old peer parsing a new frame sees `id`/`timestamp`/`thread_id`/`thread_name`/`message_id` as unknown keys and sweeps them into `payload`, exactly as it sweeps any other unknown key today.
- A new peer parsing an old frame gets the routing fields at their defaults (a fresh `id`, a `now()` timestamp, `thread_id=None`), which the runtime gate then stamps as before.

## Tests

`tests/test_events_custom_wire.py` (new) covers three layers: the adapter keeps routing on a stamped custom event and re-nests shadowing payload keys; the runtime gate stamps the declared field; a real `CoordinatorEndpoint` plus `CoordinatorClient` agree on routing (filtered subscription fires, `get_events` returns the id, client-side `append_event` lands, a rejected append shows up on `append_errors`). `tests/test_pure_functions.py` and `tests/test_reconstruct_roundtrip.py` gain the union-order and round-trip cases.

## Gate

Run on this branch (`23c9ce39`, base `1125f0c4`), mcp 2.1.1:

```
ruff format --check src tests   1 file would be reformatted (pre-existing on main: src/ai_functions/memory/base.py), 108 already formatted
hatch run lint                  All checks passed!
hatch run check-spec            Success: no issues found in 80 modules
hatch run test                  487 passed, 2 skipped
```
